### PR TITLE
Add a storage abstraction

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -1,0 +1,44 @@
+package gitobj
+
+import (
+	"io"
+
+	"github.com/git-lfs/gitobj/pack"
+	"github.com/git-lfs/gitobj/storage"
+)
+
+// NewFilesystemBackend initializes a new filesystem-based backend.
+func NewFilesystemBackend(root, tmp string) (storage.Backend, error) {
+	fsobj := newFileStorer(root, tmp)
+	packs, err := pack.NewStorage(root)
+	if err != nil {
+		return nil, err
+	}
+
+	return &filesystemBackend{fs: fsobj, packs: packs}, nil
+}
+
+// NewMemoryBackend initializes a new memory-based backend.
+//
+// A value of "nil" is acceptable and indicates that no entries should be added
+// to the memory backend at construction time.
+func NewMemoryBackend(m map[string]io.ReadWriter) (storage.Backend, error) {
+	return &memoryBackend{ms: newMemoryStorer(m)}, nil
+}
+
+type filesystemBackend struct {
+	fs    *fileStorer
+	packs *pack.Storage
+}
+
+func (b *filesystemBackend) Storage() (storage.Storage, storage.WritableStorage) {
+	return storage.MultiStorage(b.fs, b.packs), b.fs
+}
+
+type memoryBackend struct {
+	ms *memoryStorer
+}
+
+func (b *memoryBackend) Storage() (storage.Storage, storage.WritableStorage) {
+	return b.ms, b.ms
+}

--- a/backend_test.go
+++ b/backend_test.go
@@ -1,0 +1,64 @@
+package gitobj
+
+import (
+	"bytes"
+	"encoding/hex"
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewMemoryBackend(t *testing.T) {
+	backend, err := NewMemoryBackend(nil)
+	assert.NoError(t, err)
+
+	ro, rw := backend.Storage()
+	assert.Equal(t, ro, rw)
+	assert.NotNil(t, ro.(*memoryStorer))
+}
+
+func TestNewMemoryBackendWithReadOnlyData(t *testing.T) {
+	sha := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	oid, err := hex.DecodeString(sha)
+
+	assert.Nil(t, err)
+
+	m := map[string]io.ReadWriter{
+		sha: bytes.NewBuffer([]byte{0x1}),
+	}
+
+	backend, err := NewMemoryBackend(m)
+	assert.NoError(t, err)
+
+	ro, _ := backend.Storage()
+	reader, err := ro.Open(oid)
+	assert.NoError(t, err)
+
+	contents, err := ioutil.ReadAll(reader)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte{0x1}, contents)
+}
+
+func TestNewMemoryBackendWithWritableData(t *testing.T) {
+	sha := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	oid, err := hex.DecodeString(sha)
+
+	assert.Nil(t, err)
+
+	backend, err := NewMemoryBackend(make(map[string]io.ReadWriter))
+	assert.NoError(t, err)
+
+	buf := bytes.NewBuffer([]byte{0x1})
+
+	ro, rw := backend.Storage()
+	rw.Store(oid, buf)
+
+	reader, err := ro.Open(oid)
+	assert.NoError(t, err)
+
+	contents, err := ioutil.ReadAll(reader)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte{0x1}, contents)
+}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,0 +1,28 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// noSuchObject is an error type that occurs when no object with a given object
+// ID is available.
+type noSuchObject struct {
+	oid []byte
+}
+
+// Error implements the error.Error() function.
+func (e *noSuchObject) Error() string {
+	return fmt.Sprintf("gitobj: no such object: %x", e.oid)
+}
+
+// NoSuchObject creates a new error representing a missing object with a given
+// object ID.
+func NoSuchObject(oid []byte) error {
+	return &noSuchObject{oid: oid}
+}
+
+// IsNoSuchObject indicates whether an error is a noSuchObject and is non-nil.
+func IsNoSuchObject(e error) bool {
+	err, ok := e.(*noSuchObject)
+	return ok && err != nil
+}

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -1,0 +1,24 @@
+package errors
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNoSuchObjectTypeErrFormatting(t *testing.T) {
+	sha := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	oid, err := hex.DecodeString(sha)
+	assert.NoError(t, err)
+
+	err = NoSuchObject(oid)
+
+	assert.Equal(t, "gitobj: no such object: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", err.Error())
+	assert.Equal(t, IsNoSuchObject(err), true)
+}
+
+func TestIsNoSuchObjectNilHandling(t *testing.T) {
+	assert.Equal(t, IsNoSuchObject((*noSuchObject)(nil)), false)
+	assert.Equal(t, IsNoSuchObject(nil), false)
+}

--- a/file_storer.go
+++ b/file_storer.go
@@ -27,13 +27,13 @@ func newFileStorer(root, tmp string) *fileStorer {
 	}
 }
 
-// Open implements the storer.Open function, and returns a io.ReadWriteCloser
+// Open implements the storer.Open function, and returns a io.ReadCloser
 // for the given SHA. If the file does not exist, or if there was any other
 // error in opening the file, an error will be returned.
 //
 // It is the caller's responsibility to close the given file "f" after its use
 // is complete.
-func (fs *fileStorer) Open(sha []byte) (f io.ReadWriteCloser, err error) {
+func (fs *fileStorer) Open(sha []byte) (f io.ReadCloser, err error) {
 	return fs.open(fs.path(sha), os.O_RDONLY)
 }
 

--- a/file_storer.go
+++ b/file_storer.go
@@ -7,6 +7,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/git-lfs/gitobj/errors"
 )
 
 // fileStorer implements the storer interface by writing to the .git/objects
@@ -34,7 +36,11 @@ func newFileStorer(root, tmp string) *fileStorer {
 // It is the caller's responsibility to close the given file "f" after its use
 // is complete.
 func (fs *fileStorer) Open(sha []byte) (f io.ReadCloser, err error) {
-	return fs.open(fs.path(sha), os.O_RDONLY)
+	f, err = fs.open(fs.path(sha), os.O_RDONLY)
+	if os.IsNotExist(err) {
+		return nil, errors.NoSuchObject(sha)
+	}
+	return f, err
 }
 
 // Store implements the storer.Store function and returns the number of bytes

--- a/file_storer.go
+++ b/file_storer.go
@@ -90,6 +90,16 @@ func (fs *fileStorer) Root() string {
 	return fs.root
 }
 
+// Close closes the file storer.
+func (fs *fileStorer) Close() error {
+	return nil
+}
+
+// IsCompressed returns true, because the file storer returns compressed data.
+func (fs *fileStorer) IsCompressed() bool {
+	return true
+}
+
 // open opens a given file.
 func (fs *fileStorer) open(path string, flag int) (*os.File, error) {
 	return os.OpenFile(path, flag, 0)

--- a/memory_storer.go
+++ b/memory_storer.go
@@ -62,6 +62,16 @@ func (ms *memoryStorer) Open(sha []byte) (f io.ReadCloser, err error) {
 	return ms.fs[key], nil
 }
 
+// Close closes the memory storer.
+func (ms *memoryStorer) Close() error {
+	return nil
+}
+
+// IsCompressed returns true, because the memory storer returns compressed data.
+func (ms *memoryStorer) IsCompressed() bool {
+	return true
+}
+
 // bufCloser wraps a type satisfying the io.ReadWriter interface with a no-op
 // Close() function, thus implementing the io.ReadWriteCloser composite
 // interface.

--- a/memory_storer.go
+++ b/memory_storer.go
@@ -51,7 +51,7 @@ func (ms *memoryStorer) Store(sha []byte, r io.Reader) (n int64, err error) {
 // Open implements the storer.Open function, and returns a io.ReadWriteCloser
 // for the given SHA. If a reader for the given SHA does not exist an error will
 // be returned.
-func (ms *memoryStorer) Open(sha []byte) (f io.ReadWriteCloser, err error) {
+func (ms *memoryStorer) Open(sha []byte) (f io.ReadCloser, err error) {
 	ms.mu.Lock()
 	defer ms.mu.Unlock()
 

--- a/memory_storer.go
+++ b/memory_storer.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
 	"sync"
+
+	"github.com/git-lfs/gitobj/errors"
 )
 
 // memoryStorer is an implementation of the storer interface that holds data for
@@ -57,7 +58,7 @@ func (ms *memoryStorer) Open(sha []byte) (f io.ReadCloser, err error) {
 
 	key := fmt.Sprintf("%x", sha)
 	if _, ok := ms.fs[key]; !ok {
-		return nil, os.ErrNotExist
+		return nil, errors.NoSuchObject(sha)
 	}
 	return ms.fs[key], nil
 }

--- a/memory_storer_test.go
+++ b/memory_storer_test.go
@@ -5,10 +5,10 @@ import (
 	"encoding/hex"
 	"io"
 	"io/ioutil"
-	"os"
 	"strings"
 	"testing"
 
+	"github.com/git-lfs/gitobj/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -47,7 +47,7 @@ func TestMemoryStorerDoesntOpenMissingEntries(t *testing.T) {
 	ms := newMemoryStorer(nil)
 
 	f, err := ms.Open(hex)
-	assert.Equal(t, os.ErrNotExist, err)
+	assert.Equal(t, errors.NoSuchObject(hex), err)
 	assert.Nil(t, f)
 }
 

--- a/memory_storer_test.go
+++ b/memory_storer_test.go
@@ -35,6 +35,7 @@ func TestMemoryStorerAcceptsNilEntries(t *testing.T) {
 
 	assert.NotNil(t, ms)
 	assert.Equal(t, 0, len(ms.fs))
+	assert.NoError(t, ms.Close())
 }
 
 func TestMemoryStorerDoesntOpenMissingEntries(t *testing.T) {

--- a/object_db.go
+++ b/object_db.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync/atomic"
 
+	"github.com/git-lfs/gitobj/errors"
 	"github.com/git-lfs/gitobj/pack"
 )
 
@@ -266,7 +267,7 @@ func (o *ObjectDatabase) save(sha []byte, buf io.Reader) ([]byte, int64, error) 
 func (o *ObjectDatabase) open(sha []byte) (*ObjectReader, error) {
 	f, err := o.s.Open(sha)
 	if err != nil {
-		if !os.IsNotExist(err) {
+		if !errors.IsNoSuchObject(err) {
 			// If there was some other issue beyond not being able
 			// to find the object, return that immediately and don't
 			// try and fallback to the *git.ObjectScanner.

--- a/object_db.go
+++ b/object_db.go
@@ -6,11 +6,9 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"strings"
 	"sync/atomic"
 
-	"github.com/git-lfs/gitobj/errors"
-	"github.com/git-lfs/gitobj/pack"
+	"github.com/git-lfs/gitobj/storage"
 )
 
 // ObjectDatabase enables the reading and writing of objects against a storage
@@ -24,11 +22,10 @@ type ObjectDatabase struct {
 	// and a value of 1 if it is closed.
 	closed uint32
 
-	// s is the storage backend which opens/creates/reads/writes.
-	s storer
-	// packs are the set of packfiles which contain all packed objects
-	// within this repository.
-	packs *pack.Set
+	// ro is the locations from which we can read objects.
+	ro storage.Storage
+	// rw is the location to which we write objects.
+	rw storage.WritableStorage
 
 	// temp directory, defaults to os.TempDir
 	tmp string
@@ -39,15 +36,24 @@ type ObjectDatabase struct {
 //
 //  /absolute/repo/path/.git/objects
 func FromFilesystem(root, tmp string) (*ObjectDatabase, error) {
-	packs, err := pack.NewSet(root)
+	b, err := NewFilesystemBackend(root, tmp)
 	if err != nil {
 		return nil, err
 	}
 
+	ro, rw := b.Storage()
 	return &ObjectDatabase{
-		tmp:   tmp,
-		s:     newFileStorer(root, tmp),
-		packs: packs,
+		tmp: tmp,
+		ro:  ro,
+		rw:  rw,
+	}, nil
+}
+
+func FromBackend(b storage.Backend) (*ObjectDatabase, error) {
+	ro, rw := b.Storage()
+	return &ObjectDatabase{
+		ro: ro,
+		rw: rw,
 	}, nil
 }
 
@@ -61,7 +67,10 @@ func (o *ObjectDatabase) Close() error {
 		return fmt.Errorf("gitobj: *ObjectDatabase already closed")
 	}
 
-	if err := o.packs.Close(); err != nil {
+	if err := o.ro.Close(); err != nil {
+		return err
+	}
+	if err := o.rw.Close(); err != nil {
 		return err
 	}
 	return nil
@@ -203,7 +212,7 @@ func (o *ObjectDatabase) Root() (string, bool) {
 		Root() string
 	}
 
-	if root, ok := o.s.(rooter); ok {
+	if root, ok := o.rw.(rooter); ok {
 		return root.Root(), true
 	}
 	return "", false
@@ -257,7 +266,7 @@ func (d *ObjectDatabase) encodeBuffer(object Object, buf io.ReadWriter) (sha []b
 // save writes the given buffer to the location given by the storer "o.s" as
 // identified by the sha []byte.
 func (o *ObjectDatabase) save(sha []byte, buf io.Reader) ([]byte, int64, error) {
-	n, err := o.s.Store(sha, buf)
+	n, err := o.rw.Store(sha, buf)
 
 	return sha, n, err
 }
@@ -265,44 +274,18 @@ func (o *ObjectDatabase) save(sha []byte, buf io.Reader) ([]byte, int64, error) 
 // open gives an `*ObjectReader` for the given loose object keyed by the given
 // "sha" []byte, or an error.
 func (o *ObjectDatabase) open(sha []byte) (*ObjectReader, error) {
-	f, err := o.s.Open(sha)
-	if err != nil {
-		if !errors.IsNoSuchObject(err) {
-			// If there was some other issue beyond not being able
-			// to find the object, return that immediately and don't
-			// try and fallback to the *git.ObjectScanner.
-			return nil, err
-		}
-
-		// Otherwise, if the file simply couldn't be found, attempt to
-		// load its contents from the *git.ObjectScanner by leveraging
-		// `git-cat-file --batch`.
-		if atomic.LoadUint32(&o.closed) == 1 {
-			return nil, fmt.Errorf("gitobj: cannot use closed *pack.Set")
-		}
-
-		packed, err := o.packs.Object(sha)
-		if err != nil {
-			return nil, err
-		}
-
-		unpacked, err := packed.Unpack()
-		if err != nil {
-			return nil, err
-		}
-
-		return NewUncompressedObjectReader(io.MultiReader(
-			// Git object header:
-			strings.NewReader(fmt.Sprintf("%s %d\x00",
-				packed.Type(), len(unpacked),
-			)),
-
-			// Git object (uncompressed) contents:
-			bytes.NewReader(unpacked),
-		))
+	if atomic.LoadUint32(&o.closed) == 1 {
+		return nil, fmt.Errorf("gitobj: cannot use closed *pack.Set")
 	}
 
-	return NewObjectReadCloser(f)
+	f, err := o.ro.Open(sha)
+	if err != nil {
+		return nil, err
+	}
+	if o.ro.IsCompressed() {
+		return NewObjectReadCloser(f)
+	}
+	return NewUncompressedObjectReader(f)
 }
 
 // openDecode calls decode (see: below) on the object named "sha" after openin

--- a/pack/delayed_object.go
+++ b/pack/delayed_object.go
@@ -1,0 +1,41 @@
+package pack
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// delayedObjectReader provides an interface for reading from an Object while
+// loading object data into memory only on demand.  It implements io.ReadCloser.
+type delayedObjectReader struct {
+	obj *Object
+	mr  io.Reader
+}
+
+// Read implements the io.Reader method by instantiating a new underlying reader
+// only on demand.
+func (d *delayedObjectReader) Read(b []byte) (int, error) {
+	if d.mr == nil {
+		data, err := d.obj.Unpack()
+		if err != nil {
+			return 0, err
+		}
+		d.mr = io.MultiReader(
+			// Git object header:
+			strings.NewReader(fmt.Sprintf("%s %d\x00",
+				d.obj.Type(), len(data),
+			)),
+
+			// Git object (uncompressed) contents:
+			bytes.NewReader(data),
+		)
+	}
+	return d.mr.Read(b)
+}
+
+// Close implements the io.Closer interface.
+func (d *delayedObjectReader) Close() error {
+	return nil
+}

--- a/pack/set.go
+++ b/pack/set.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+
+	"github.com/git-lfs/gitobj/errors"
 )
 
 // Set allows access of objects stored across a set of packfiles.
@@ -162,8 +164,8 @@ type iterFn func(p *Packfile) (o *Object, err error)
 // returned immediately, if the error is not ErrIsNotFound, or b) continued
 // immediately, if the error is ErrNotFound.
 //
-// If no packfiles match the given file, return ErrIsNotFound, along with no
-// object.
+// If no packfiles match the given file, return errors.NoSuchObject, along with
+// no object.
 func (s *Set) each(name []byte, fn iterFn) (*Object, error) {
 	var key byte
 	if len(name) > 0 {
@@ -181,5 +183,5 @@ func (s *Set) each(name []byte, fn iterFn) (*Object, error) {
 		return o, nil
 	}
 
-	return nil, errNotFound
+	return nil, errors.NoSuchObject(name)
 }

--- a/pack/storage.go
+++ b/pack/storage.go
@@ -1,0 +1,38 @@
+package pack
+
+import (
+	"io"
+)
+
+// Storage implements the storage.Storage interface.
+type Storage struct {
+	packs *Set
+}
+
+// NewStorage returns a new storage object based on a pack set.
+func NewStorage(root string) (*Storage, error) {
+	packs, err := NewSet(root)
+	if err != nil {
+		return nil, err
+	}
+	return &Storage{packs: packs}, nil
+}
+
+// Open implements the storage.Storage.Open interface.
+func (f *Storage) Open(oid []byte) (r io.ReadCloser, err error) {
+	obj, err := f.packs.Object(oid)
+	if err != nil {
+		return nil, err
+	}
+	return &delayedObjectReader{obj: obj}, nil
+}
+
+// Open implements the storage.Storage.Open interface.
+func (f *Storage) Close() error {
+	return f.packs.Close()
+}
+
+// IsCompressed returns false, because data returned is already decompressed.
+func (f *Storage) IsCompressed() bool {
+	return false
+}

--- a/storage/backend.go
+++ b/storage/backend.go
@@ -1,0 +1,10 @@
+package storage
+
+// Backend is an encapsulation of a set of read-only and read-write interfaces
+// for reading and writing objects.
+type Backend interface {
+	// Storage returns a read source and optionally a write source.
+	// Generally, the write location, if present, should also be a read
+	// location.
+	Storage() (Storage, WritableStorage)
+}

--- a/storage/decompressing_readcloser.go
+++ b/storage/decompressing_readcloser.go
@@ -1,0 +1,35 @@
+package storage
+
+import (
+	"compress/zlib"
+	"io"
+)
+
+// decompressingReadCloser wraps zlib.NewReader to ensure that both the zlib
+// reader and its underlying type are closed.
+type decompressingReadCloser struct {
+	r  io.ReadCloser
+	zr io.ReadCloser
+}
+
+// newDecompressingReadCloser creates a new wrapped zlib reader
+func newDecompressingReadCloser(r io.ReadCloser) (io.ReadCloser, error) {
+	zr, err := zlib.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+	return &decompressingReadCloser{r: r, zr: zr}, nil
+}
+
+// Read implements io.ReadCloser.
+func (d *decompressingReadCloser) Read(b []byte) (int, error) {
+	return d.zr.Read(b)
+}
+
+// Close implements io.ReadCloser.
+func (d *decompressingReadCloser) Close() error {
+	if err := d.zr.Close(); err != nil {
+		return err
+	}
+	return d.r.Close()
+}

--- a/storage/multi_storage.go
+++ b/storage/multi_storage.go
@@ -1,0 +1,55 @@
+package storage
+
+import (
+	"io"
+
+	"github.com/git-lfs/gitobj/errors"
+)
+
+// Storage implements an interface for reading, but not writing, objects in an
+// object database.
+type multiStorage struct {
+	impls []Storage
+}
+
+func MultiStorage(args ...Storage) Storage {
+	return &multiStorage{impls: args}
+}
+
+// Open returns a handle on an existing object keyed by the given object
+// ID.  It returns an error if that file does not already exist.
+func (m *multiStorage) Open(oid []byte) (f io.ReadCloser, err error) {
+	for _, s := range m.impls {
+		f, err := s.Open(oid)
+		if err != nil {
+			if errors.IsNoSuchObject(err) {
+				continue
+			}
+			return nil, err
+		}
+		if s.IsCompressed() {
+			return newDecompressingReadCloser(f)
+		}
+		return f, nil
+	}
+	return nil, errors.NoSuchObject(oid)
+}
+
+// Close closes the filesystem, after which no more operations are
+// allowed.
+func (m *multiStorage) Close() error {
+	for _, s := range m.impls {
+		if err := s.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Compressed indicates whether data read from this storage source will
+// be zlib-compressed.
+func (m *multiStorage) IsCompressed() bool {
+	// To ensure we can read from any Storage type, we automatically
+	// decompress items if they need it.
+	return false
+}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1,0 +1,30 @@
+package storage
+
+import "io"
+
+// Storage implements an interface for reading, but not writing, objects in an
+// object database.
+type Storage interface {
+	// Open returns a handle on an existing object keyed by the given object
+	// ID.  It returns an error if that file does not already exist.
+	Open(oid []byte) (f io.ReadCloser, err error)
+
+	// Close closes the filesystem, after which no more operations are
+	// allowed.
+	Close() error
+
+	// Compressed indicates whether data read from this storage source will
+	// be zlib-compressed.
+	IsCompressed() bool
+}
+
+// WritableStorage implements an interface for reading and writing objects in
+// an object database.
+type WritableStorage interface {
+	Storage
+
+	// Store copies the data given in "r" to the unique object path given by
+	// "oid". It returns an error if that file already exists (acting as if
+	// the `os.O_EXCL` mode is given in a bitmask to os.Open).
+	Store(oid []byte, r io.Reader) (n int64, err error)
+}

--- a/storer.go
+++ b/storer.go
@@ -7,7 +7,7 @@ import "io"
 type storer interface {
 	// Open returns a handle on an existing object keyed by the given SHA.
 	// It returns an error if that file does not already exist.
-	Open(sha []byte) (f io.ReadWriteCloser, err error)
+	Open(sha []byte) (f io.ReadCloser, err error)
 
 	// Store copies the data given in "r" to the unique object path given by
 	// "sha". It returns an error if that file already exists (acting as if


### PR DESCRIPTION
Currently we have a storer abstraction, but it isn't exposed, making it hard to mock the disk in unit tests that use this module.  This series wraps both the existing storers and the pack piece in a storage abstraction that can be overridden and used elsewhere.  It also provides a consistent error type so that we can tell when an object is missing versus when there's some more serious error.

This series is marked RFC because while I think it should be done, I'm finalizing the use of it in git-lfs/git-lfs and I want to be sure that if I need to make any changes that I do it before this series merges.