### PR TITLE
object_db: use ReadCloser for uncompressed objects

### DIFF
--- a/object_db.go
+++ b/object_db.go
@@ -285,7 +285,7 @@ func (o *ObjectDatabase) open(sha []byte) (*ObjectReader, error) {
 	if o.ro.IsCompressed() {
 		return NewObjectReadCloser(f)
 	}
-	return NewUncompressedObjectReader(f)
+	return NewUncompressedObjectReadCloser(f)
 }
 
 // openDecode calls decode (see: below) on the object named "sha" after openin


### PR DESCRIPTION
When we open a new object using the object database, ensure that we use
a ReadCloser for the uncompressed object.  This ensures that we close
the file we've opened when reading loose objects so we don't run out of
file descriptors.

Note that we do use this code path for reading loose objects in some
cases because we hand it a ReadCloser which automatically decompresses
the object.