### PR TITLE
Handle alternates

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -15,7 +15,10 @@ func NewFilesystemBackend(root, tmp string) (storage.Backend, error) {
 		return nil, err
 	}
 
-	return &filesystemBackend{fs: fsobj, packs: packs}, nil
+	return &filesystemBackend{
+		fs:       fsobj,
+		backends: []storage.Storage{fsobj, packs},
+	}, nil
 }
 
 // NewMemoryBackend initializes a new memory-based backend.
@@ -27,12 +30,12 @@ func NewMemoryBackend(m map[string]io.ReadWriter) (storage.Backend, error) {
 }
 
 type filesystemBackend struct {
-	fs    *fileStorer
-	packs *pack.Storage
+	fs       *fileStorer
+	backends []storage.Storage
 }
 
 func (b *filesystemBackend) Storage() (storage.Storage, storage.WritableStorage) {
-	return storage.MultiStorage(b.fs, b.packs), b.fs
+	return storage.MultiStorage(b.backends...), b.fs
 }
 
 type memoryBackend struct {


### PR DESCRIPTION
Previously, `gitobj` didn't handle reading and writing from alternate repositories.  Teach it to do so by creating multiple storage backends for reading and continuing to write into our current repository.

Note that because we have no integration tests for this repository, there are no tests for this.  I have manually tested and confirmed that this series works where it did not before.