### PR TITLE
pack/set: ignore packs without indices

### DIFF
--- a/pack/set.go
+++ b/pack/set.go
@@ -55,12 +55,15 @@ func NewSet(db string) (*Set, error) {
 
 		name := submatch[1]
 
-		packf, err := os.Open(filepath.Join(pd, fmt.Sprintf("pack-%s.pack", name)))
+		idxf, err := os.Open(filepath.Join(pd, fmt.Sprintf("pack-%s.idx", name)))
 		if err != nil {
-			return nil, err
+			// We have a pack (since it matched the regex), but the
+			// index is missing or unusable.  Skip this pack and
+			// continue on with the next one, as Git does.
+			continue
 		}
 
-		idxf, err := os.Open(filepath.Join(pd, fmt.Sprintf("pack-%s.idx", name)))
+		packf, err := os.Open(filepath.Join(pd, fmt.Sprintf("pack-%s.pack", name)))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
When we look for packs to read, we look for a pack file, and then an index, and fail if either one is missing.  When Git looks for packs to read, it looks only for indices and then checks if the pack is present.

The Git approach handles the case when there is an extra pack that lacks an index, while our approach does not.  Consequently, we can get various errors (showing up so far only on Windows) when an index is missing.

If the index file cannot be read for any reason, simply skip the entire pack altogether and continue on.  This leaves us no more or less functional than Git in terms of discovering objects and makes our error handling more robust.