### PR TITLE
pack/set.go: close potentially-opened index files

### DIFF
--- a/pack/set.go
+++ b/pack/set.go
@@ -60,6 +60,12 @@ func NewSet(db string) (*Set, error) {
 			// We have a pack (since it matched the regex), but the
 			// index is missing or unusable.  Skip this pack and
 			// continue on with the next one, as Git does.
+			if idxf != nil {
+				// In the unlikely event that we did open a
+				// file, close it, but discard any error in
+				// doing so.
+				idxf.Close()
+			}
 			continue
 		}
 


### PR DESCRIPTION
In [1], we matched upstream Git's behavior more closely by (1) first
opening the corresponding *.idx, and _then_ opening the associated
*.pack, skipping over any pairs which had missing/corrupt index files.

In this commit, augment that behavior by closing a file descriptor we
may have opened, but is otherwise deemed by os.Open to be unusable for
one reason or another.

This path is unlikely in practice, but is a safe change nonetheless.

[1]: 561ed224 (pack/set: ignore packs without indices, 2018-11-29)

##

/cc @git-lfs/core 
/cc https://github.com/git-lfs/gitobj/pull/8