### PR TITLE
commit.go: support multi-line header continuations

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -105,7 +105,18 @@ func (c *Commit) Decode(from io.Reader, size int64) (n int, err error) {
 			continue
 		}
 
-		if fields := strings.Fields(text); len(fields) > 0 && !finishedHeaders {
+		if fields := strings.Fields(text); !finishedHeaders {
+			if len(fields) == 0 {
+				// Executing in this block means that we got a
+				// whitespace-only line, while parsing a header.
+				//
+				// Append it to the last-parsed header, and
+				// continue.
+				c.ExtraHeaders[len(c.ExtraHeaders)-1].V +=
+					fmt.Sprintf("\n%s", text[1:])
+				continue
+			}
+
 			switch fields[0] {
 			case "tree":
 				id, err := hex.DecodeString(fields[1])


### PR DESCRIPTION
When Git wishes to continue one or more of a commit's extra headers on
more than a single line, it writes out the following:

```
parent: <SHA-1>
tree: <SHA-1>
...
gpgsig: -----BEGIN PGP SIGNATURE-----
 <signature>
 -----END PGP SIGNATURE-----
```

Our current parsing implementation does not handle this correctly, based
on a misunderstanding that one line is equivalent to one extra header,
and vice versa.

In fact, the situation presently is even more dire than not parsing the
'gpgsig' header incorrectly: we'll split the signature end ending line
into their own "headers" and in doing so trim off the leading
whitespace. In practice, this means that we can corrupt commits when
round-tripping them in many interesting ways \[1\].

To address the situation, we do two things:

  1. Teach gitobj that when we are parsing extra headers for a commit,
     _and_ a header line begins with a single whitespace character, we
     are in fact continuing the last known header.

  2. Likewise, teach gitobj that when encoding a commit which has an
     extra header whose value contains a LF character, replace each LF
     with a leading space, to round trip commits of this form
     successfully.

Together, (1) and (2) means that we parse the 'gpgsig' header in the
above example as a _single_ entry in the commit's 'ExtraHeaders' field,
as expected.

\[1\]: https://github.com/git-lfs/git-lfs/issues/3530

## 

/cc @git-lfs/core, especially @bk2204 
/cc https://github.com/git-lfs/git-lfs/issues/3530