### PR TITLE
Search packs as Git does

### DIFF
--- a/pack/set.go
+++ b/pack/set.go
@@ -27,7 +27,7 @@ var (
 	// filepath that is a packfile.
 	//
 	// It includes one matchgroup, which is the SHA-1 name of the pack.
-	nameRe = regexp.MustCompile(`^pack-([a-f0-9]{40}).pack$`)
+	nameRe = regexp.MustCompile(`^(.*)\.pack$`)
 )
 
 // NewSet creates a new *Set of all packfiles found in a given object database's
@@ -40,7 +40,7 @@ var (
 func NewSet(db string) (*Set, error) {
 	pd := filepath.Join(db, "pack")
 
-	paths, err := filepath.Glob(filepath.Join(pd, "pack-*.pack"))
+	paths, err := filepath.Glob(filepath.Join(pd, "*.pack"))
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func NewSet(db string) (*Set, error) {
 
 		name := submatch[1]
 
-		idxf, err := os.Open(filepath.Join(pd, fmt.Sprintf("pack-%s.idx", name)))
+		idxf, err := os.Open(filepath.Join(pd, fmt.Sprintf("%s.idx", name)))
 		if err != nil {
 			// We have a pack (since it matched the regex), but the
 			// index is missing or unusable.  Skip this pack and
@@ -69,7 +69,7 @@ func NewSet(db string) (*Set, error) {
 			continue
 		}
 
-		packf, err := os.Open(filepath.Join(pd, fmt.Sprintf("pack-%s.pack", name)))
+		packf, err := os.Open(filepath.Join(pd, fmt.Sprintf("%s.pack", name)))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Git inteprets any files with .pack extensions as packs.
For example, look at prepare_pack function in https://github.com/git/git/blob/master/packfile.c
We should use same rules for Git LFS to prevent problems with arbitrary pack names.