### PR TITLE
fixbug: find alternates may fails

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/git-lfs/gitobj/pack"
 	"github.com/git-lfs/gitobj/storage"
@@ -45,8 +46,12 @@ func findAllBackends(mainLoose *fileStorer, mainPacked *pack.Storage, root strin
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
-		storage = append(storage, newFileStorer(scanner.Text(), ""))
-		pack, err := pack.NewStorage(scanner.Text())
+		alternateRoot := scanner.Text()
+		if !filepath.IsAbs(alternateRoot) {
+			alternateRoot = filepath.Join(root, scanner.Text())
+		}
+		storage = append(storage, newFileStorer(alternateRoot, ""))
+		pack, err := pack.NewStorage(alternateRoot)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
`findAllBackends` will fails if current directory is not the repository
root path while the path in the alternates file is relative. And if
current directory is not right, latter `Scan` will lost the objects under
the alternates dbs. So change the relative alternate paths to `Abs`
paths to create the storage objects, then the latter `Scan` works well.