### PR TITLE
object_db: prevent FD leaks when writing blobs

### DIFF
--- a/object_db.go
+++ b/object_db.go
@@ -158,7 +158,7 @@ func (o *ObjectDatabase) WriteBlob(b *Blob) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer os.Remove(buf.Name())
+	defer o.cleanup(buf)
 
 	sha, _, err := o.encodeBuffer(b, buf)
 	if err != nil {
@@ -236,7 +236,7 @@ func (d *ObjectDatabase) encodeBuffer(object Object, buf io.ReadWriter) (sha []b
 	if err != nil {
 		return nil, 0, err
 	}
-	defer os.Remove(tmp.Name())
+	defer d.cleanup(tmp)
 
 	to := NewObjectWriter(tmp)
 	if _, err = to.WriteHeader(object.Type(), int64(cn)); err != nil {
@@ -322,4 +322,9 @@ func (o *ObjectDatabase) decode(r *ObjectReader, into Object) error {
 		return nil
 	}
 	return r.Close()
+}
+
+func (o *ObjectDatabase) cleanup(f *os.File) {
+	f.Close()
+	os.Remove(f.Name())
 }


### PR DESCRIPTION
When writing a blob, there are two places where we use temporary files. First, we use them when we write the blob itself. Second, we use them when we encode the buffer. In both of these cases, however, we failed to close the file after we were done with it, leading to file descriptor leaks until Go garbage-collected the items.

Close each of these files when we're done with them. Place the defer statements after the os.Remove statements, since defer statements are done in LIFO order and Windows will be happier if we don't try to remove a file we have open.

With this change, I don't see any of the lingering files I reported in the original issue; they're all routinely closed, and only the pack remains open.

Fixes git-lfs/git-lfs#3689
/cc @ttaylorr as contributor
/cc @larsxschneider as reporter