### PR TITLE
Alternate object directories

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -45,12 +45,10 @@ func findAllBackends(mainLoose *fileStorer, mainPacked *pack.Storage, root strin
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
-		storage = append(storage, newFileStorer(scanner.Text(), ""))
-		pack, err := pack.NewStorage(scanner.Text())
+		storage, err = addAlternateDirectory(storage, scanner.Text())
 		if err != nil {
 			return nil, err
 		}
-		storage = append(storage, pack)
 	}
 
 	if err := scanner.Err(); err != nil {
@@ -58,6 +56,16 @@ func findAllBackends(mainLoose *fileStorer, mainPacked *pack.Storage, root strin
 	}
 
 	return storage, nil
+}
+
+func addAlternateDirectory(s []storage.Storage, dir string) ([]storage.Storage, error) {
+	s = append(s, newFileStorer(dir, ""))
+	pack, err := pack.NewStorage(dir)
+	if err != nil {
+		return s, err
+	}
+	s = append(s, pack)
+	return s, nil
 }
 
 // NewMemoryBackend initializes a new memory-based backend.

--- a/backend.go
+++ b/backend.go
@@ -5,6 +5,9 @@ import (
 	"io"
 	"os"
 	"path"
+	"regexp"
+	"strconv"
+	"strings"
 
 	"github.com/git-lfs/gitobj/pack"
 	"github.com/git-lfs/gitobj/storage"
@@ -12,6 +15,14 @@ import (
 
 // NewFilesystemBackend initializes a new filesystem-based backend.
 func NewFilesystemBackend(root, tmp string) (storage.Backend, error) {
+	return NewFilesystemBackendWithAlternates(root, tmp, "")
+}
+
+// NewFilesystemBackendWithAlternates initializes a new filesystem-based
+// backend, optionally with additional alternates as specified in the
+// `alternates` variable. The syntax is that of the Git environment variable
+// GIT_ALTERNATE_OBJECT_DIRECTORIES.
+func NewFilesystemBackendWithAlternates(root, tmp, alternates string) (storage.Backend, error) {
 	fsobj := newFileStorer(root, tmp)
 	packs, err := pack.NewStorage(root)
 	if err != nil {
@@ -19,6 +30,11 @@ func NewFilesystemBackend(root, tmp string) (storage.Backend, error) {
 	}
 
 	storage, err := findAllBackends(fsobj, packs, root)
+	if err != nil {
+		return nil, err
+	}
+
+	storage, err = addAlternatesFromEnvironment(storage, alternates)
 	if err != nil {
 		return nil, err
 	}
@@ -66,6 +82,66 @@ func addAlternateDirectory(s []storage.Storage, dir string) ([]storage.Storage, 
 	}
 	s = append(s, pack)
 	return s, nil
+}
+
+func addAlternatesFromEnvironment(s []storage.Storage, env string) ([]storage.Storage, error) {
+	if len(env) == 0 {
+		return s, nil
+	}
+
+	for _, dir := range splitAlternateString(env, alternatesSeparator) {
+		var err error
+		s, err = addAlternateDirectory(s, dir)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return s, nil
+}
+
+var (
+	octalEscape  = regexp.MustCompile("\\\\[0-7]{1,3}")
+	hexEscape    = regexp.MustCompile("\\\\x[0-9a-fA-F]{2}")
+	replacements = []struct {
+		olds string
+		news string
+	}{
+		{`\a`, "\a"},
+		{`\b`, "\b"},
+		{`\t`, "\t"},
+		{`\n`, "\n"},
+		{`\v`, "\v"},
+		{`\f`, "\f"},
+		{`\r`, "\r"},
+		{`\\`, "\\"},
+		{`\"`, "\""},
+		{`\'`, "'"},
+	}
+)
+
+func splitAlternateString(env string, separator string) []string {
+	dirs := strings.Split(env, separator)
+	for i, s := range dirs {
+		if !strings.HasPrefix(s, `"`) || !strings.HasSuffix(s, `"`) {
+			continue
+		}
+
+		// Strip leading and trailing quotation marks
+		s = s[1 : len(s)-1]
+		for _, repl := range replacements {
+			s = strings.Replace(s, repl.olds, repl.news, -1)
+		}
+		s = octalEscape.ReplaceAllStringFunc(s, func(inp string) string {
+			val, _ := strconv.ParseUint(inp[1:], 8, 64)
+			return string([]byte{byte(val)})
+		})
+		s = hexEscape.ReplaceAllStringFunc(s, func(inp string) string {
+			val, _ := strconv.ParseUint(inp[2:], 16, 64)
+			return string([]byte{byte(val)})
+		})
+		dirs[i] = s
+	}
+	return dirs
 }
 
 // NewMemoryBackend initializes a new memory-based backend.

--- a/backend_nix.go
+++ b/backend_nix.go
@@ -1,0 +1,5 @@
+// +build !windows
+
+package gitobj
+
+const alternatesSeparator = ":"

--- a/backend_windows.go
+++ b/backend_windows.go
@@ -1,0 +1,5 @@
+// +build windows
+
+package gitobj
+
+const alternatesSeparator = ";"

--- a/object_db.go
+++ b/object_db.go
@@ -36,7 +36,16 @@ type ObjectDatabase struct {
 //
 //  /absolute/repo/path/.git/objects
 func FromFilesystem(root, tmp string) (*ObjectDatabase, error) {
-	b, err := NewFilesystemBackend(root, tmp)
+	return FromFilesystemWithAlternates(root, tmp, "")
+}
+
+// FromFilesystemWithAlternates constructs an *ObjectDatabase instance that is
+// backed by a directory on the filesystem, optionally with one or more
+// alternates. Specifically, this should point to:
+//
+//  /absolute/repo/path/.git/objects
+func FromFilesystemWithAlternates(root, tmp, alternates string) (*ObjectDatabase, error) {
+	b, err := NewFilesystemBackendWithAlternates(root, tmp, alternates)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
gitobj already supports reading alternates from the alternates file in the repository, but not from the `GIT_ALTERNATE_OBJECT_DIRECTORIES` environment variable. This series introduces a way to pass in such an environment variable so that it can be parsed and alternate paths can be read.

The actual reading of the environment variable comes in with Git LFS itself, which passes it to these functions. This happens so that we can centralize the handling of environment variables in one location.

This is part of the fix for #14; the remainder will come into Git LFS after this is merged.