### PR TITLE
go.mod: add Go version directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,3 +5,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
 )
+
+go 1.11


### PR DESCRIPTION
Go 1.13 really wants a Go version declaration at the bottom of the file and will modify it when any go command is run if it isn't present.  Because we'd like our files to be tidy and not show up as modified when we build or run tests, add a Go version declaration for Go 1.11 (the oldest we support) at the bottom of the file.