### PR TITLE
Allow parsing very long lines in commit messages

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -96,6 +96,7 @@ func (c *Commit) Decode(from io.Reader, size int64) (n int, err error) {
 	var messageParts []string
 
 	s := bufio.NewScanner(from)
+	s.Buffer(nil, 1024 * 1024)
 	for s.Scan() {
 		text := s.Text()
 		n = n + len(text+"\n")
@@ -169,7 +170,7 @@ func (c *Commit) Decode(from io.Reader, size int64) (n int, err error) {
 	c.Message = strings.Join(messageParts, "\n")
 
 	if err = s.Err(); err != nil {
-		return n, err
+		return n, fmt.Errorf("failed to parse commit buffer: %s", err)
 	}
 	return n, err
 }

--- a/commit_test.go
+++ b/commit_test.go
@@ -117,6 +117,37 @@ func TestCommitDecodingWithEmptyName(t *testing.T) {
 	assert.Equal(t, "initial commit", commit.Message)
 }
 
+func TestCommitDecodingWithLargeCommitMessage(t *testing.T) {
+	message := "This message text is, with newline, exactly 64 characters long. ";
+	// This message will be exactly 1 MiB in size when part of the commit.
+	longMessage := strings.Repeat(message, (1024 * 1024 / 64) - 1)
+	longMessage += strings.TrimSpace(message);
+
+	author := &Signature{Name: "", Email: "john@example.com", When: time.Now()}
+	committer := &Signature{Name: "", Email: "jane@example.com", When: time.Now()}
+
+	treeId := []byte("cccccccccccccccccccc")
+
+	from := new(bytes.Buffer)
+
+	fmt.Fprintf(from, "author %s\n", author)
+	fmt.Fprintf(from, "committer %s\n", committer)
+	fmt.Fprintf(from, "tree %s\n", hex.EncodeToString(treeId))
+	fmt.Fprintf(from, "\n%s\n", longMessage)
+
+	flen := from.Len()
+
+	commit := new(Commit)
+	n, err := commit.Decode(from, int64(flen))
+
+	assert.Nil(t, err)
+	assert.Equal(t, flen, n)
+
+	assert.Equal(t, author.String(), commit.Author)
+	assert.Equal(t, committer.String(), commit.Committer)
+	assert.Equal(t, longMessage, commit.Message)
+}
+
 func TestCommitDecodingWithMessageKeywordPrefix(t *testing.T) {
 	author := &Signature{Name: "John Doe", Email: "john@example.com", When: time.Now()}
 	committer := &Signature{Name: "Jane Doe", Email: "jane@example.com", When: time.Now()}


### PR DESCRIPTION
It's technically possible for commit messages to contain arbitrary non-NUL bytes.  Our commit message parser uses a 64 KiB buffer to read lines, and if lines are too long, it will fail.  We've seen some cases where commit message lines are much longer due to historical accidents.

Let's raise the maximum buffer size to 1 MiB to accommodate these situations.  Let's also make it easier to track problems by returning a more helpful error message if the buffer size is exceeded.

Fixes git-lfs/git-lfs#4005
/cc @woopla as reporter