### PR TITLE
Add support for SHA-256

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/git-lfs/gitobj/pack"
-	"github.com/git-lfs/gitobj/storage"
+	"github.com/git-lfs/gitobj/v2/pack"
+	"github.com/git-lfs/gitobj/v2/storage"
 )
 
 // NewFilesystemBackend initializes a new filesystem-based backend.

--- a/backend.go
+++ b/backend.go
@@ -2,6 +2,7 @@ package gitobj
 
 import (
 	"bufio"
+	"hash"
 	"io"
 	"os"
 	"path"
@@ -13,16 +14,12 @@ import (
 	"github.com/git-lfs/gitobj/v2/storage"
 )
 
-// NewFilesystemBackend initializes a new filesystem-based backend.
-func NewFilesystemBackend(root, tmp string) (storage.Backend, error) {
-	return NewFilesystemBackendWithAlternates(root, tmp, "")
-}
-
-// NewFilesystemBackendWithAlternates initializes a new filesystem-based
-// backend, optionally with additional alternates as specified in the
+// NewFilesystemBackend initializes a new filesystem-based backend,
+// optionally with additional alternates as specified in the
 // `alternates` variable. The syntax is that of the Git environment variable
-// GIT_ALTERNATE_OBJECT_DIRECTORIES.
-func NewFilesystemBackendWithAlternates(root, tmp, alternates string) (storage.Backend, error) {
+// GIT_ALTERNATE_OBJECT_DIRECTORIES.  The hash algorithm used is specified by
+// the algo parameter.
+func NewFilesystemBackend(root, tmp, alternates string, algo hash.Hash) (storage.Backend, error) {
 	fsobj := newFileStorer(root, tmp)
 	packs, err := pack.NewStorage(root)
 	if err != nil {

--- a/blob.go
+++ b/blob.go
@@ -3,6 +3,7 @@ package gitobj
 import (
 	"bytes"
 	"fmt"
+	"hash"
 	"io"
 	"os"
 )
@@ -75,7 +76,7 @@ func (b *Blob) Type() ObjectType { return BlobObjectType }
 // stream, which is always zero.
 //
 // If any errors are encountered while reading the blob, they will be returned.
-func (b *Blob) Decode(r io.Reader, size int64) (n int, err error) {
+func (b *Blob) Decode(hash hash.Hash, r io.Reader, size int64) (n int, err error) {
 	b.Size = size
 	b.Contents = io.LimitReader(r, size)
 

--- a/blob_test.go
+++ b/blob_test.go
@@ -2,6 +2,7 @@ package gitobj
 
 import (
 	"bytes"
+	"crypto/sha1"
 	"errors"
 	"io/ioutil"
 	"strings"
@@ -48,7 +49,7 @@ func TestBlobDecoding(t *testing.T) {
 	from := strings.NewReader(contents)
 
 	b := new(Blob)
-	n, err := b.Decode(from, int64(len(contents)))
+	n, err := b.Decode(sha1.New(), from, int64(len(contents)))
 
 	assert.Equal(t, 0, n)
 	assert.Nil(t, err)

--- a/commit.go
+++ b/commit.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"hash"
 	"io"
 	"strings"
 	"time"
@@ -91,12 +92,12 @@ func (c *Commit) Type() ObjectType { return CommitObjectType }
 //
 // If any error was encountered along the way, that will be returned, along with
 // the number of bytes read up to that point.
-func (c *Commit) Decode(from io.Reader, size int64) (n int, err error) {
+func (c *Commit) Decode(hash hash.Hash, from io.Reader, size int64) (n int, err error) {
 	var finishedHeaders bool
 	var messageParts []string
 
 	s := bufio.NewScanner(from)
-	s.Buffer(nil, 1024 * 1024)
+	s.Buffer(nil, 1024*1024)
 	for s.Scan() {
 		text := s.Text()
 		n = n + len(text+"\n")

--- a/commit_test.go
+++ b/commit_test.go
@@ -119,10 +119,10 @@ func TestCommitDecodingWithEmptyName(t *testing.T) {
 }
 
 func TestCommitDecodingWithLargeCommitMessage(t *testing.T) {
-	message := "This message text is, with newline, exactly 64 characters long. ";
+	message := "This message text is, with newline, exactly 64 characters long. "
 	// This message will be exactly 1 MiB in size when part of the commit.
-	longMessage := strings.Repeat(message, (1024 * 1024 / 64) - 1)
-	longMessage += strings.TrimSpace(message);
+	longMessage := strings.Repeat(message, (1024*1024/64)-1)
+	longMessage += strings.TrimSpace(message)
 
 	author := &Signature{Name: "", Email: "john@example.com", When: time.Now()}
 	committer := &Signature{Name: "", Email: "jane@example.com", When: time.Now()}

--- a/commit_test.go
+++ b/commit_test.go
@@ -2,6 +2,7 @@ package gitobj
 
 import (
 	"bytes"
+	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -77,7 +78,7 @@ func TestCommitDecoding(t *testing.T) {
 	flen := from.Len()
 
 	commit := new(Commit)
-	n, err := commit.Decode(from, int64(flen))
+	n, err := commit.Decode(sha1.New(), from, int64(flen))
 
 	assert.Nil(t, err)
 	assert.Equal(t, flen, n)
@@ -107,7 +108,7 @@ func TestCommitDecodingWithEmptyName(t *testing.T) {
 	flen := from.Len()
 
 	commit := new(Commit)
-	n, err := commit.Decode(from, int64(flen))
+	n, err := commit.Decode(sha1.New(), from, int64(flen))
 
 	assert.Nil(t, err)
 	assert.Equal(t, flen, n)
@@ -138,7 +139,7 @@ func TestCommitDecodingWithLargeCommitMessage(t *testing.T) {
 	flen := from.Len()
 
 	commit := new(Commit)
-	n, err := commit.Decode(from, int64(flen))
+	n, err := commit.Decode(sha1.New(), from, int64(flen))
 
 	assert.Nil(t, err)
 	assert.Equal(t, flen, n)
@@ -164,7 +165,7 @@ func TestCommitDecodingWithMessageKeywordPrefix(t *testing.T) {
 	flen := from.Len()
 
 	commit := new(Commit)
-	n, err := commit.Decode(from, int64(flen))
+	n, err := commit.Decode(sha1.New(), from, int64(flen))
 
 	assert.NoError(t, err)
 	assert.Equal(t, flen, n)
@@ -191,7 +192,7 @@ func TestCommitDecodingWithWhitespace(t *testing.T) {
 	flen := from.Len()
 
 	commit := new(Commit)
-	n, err := commit.Decode(from, int64(flen))
+	n, err := commit.Decode(sha1.New(), from, int64(flen))
 
 	assert.NoError(t, err)
 	assert.Equal(t, flen, n)
@@ -221,7 +222,7 @@ func TestCommitDecodingMultilineHeader(t *testing.T) {
 	flen := from.Len()
 
 	commit := new(Commit)
-	n, err := commit.Decode(from, int64(flen))
+	n, err := commit.Decode(sha1.New(), from, int64(flen))
 
 	require.Nil(t, err)
 	require.Equal(t, flen, n)

--- a/file_storer.go
+++ b/file_storer.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/git-lfs/gitobj/errors"
+	"github.com/git-lfs/gitobj/v2/errors"
 )
 
 // fileStorer implements the storer interface by writing to the .git/objects

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/git-lfs/gitobj
+module github.com/git-lfs/gitobj/v2
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/memory_storer.go
+++ b/memory_storer.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/git-lfs/gitobj/errors"
+	"github.com/git-lfs/gitobj/v2/errors"
 )
 
 // memoryStorer is an implementation of the storer interface that holds data for

--- a/memory_storer_test.go
+++ b/memory_storer_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/git-lfs/gitobj/errors"
+	"github.com/git-lfs/gitobj/v2/errors"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/object.go
+++ b/object.go
@@ -1,6 +1,9 @@
 package gitobj
 
-import "io"
+import (
+	"hash"
+	"io"
+)
 
 // Object is an interface satisfied by any concrete type that represents a loose
 // Git object.
@@ -29,7 +32,7 @@ type Object interface {
 	//
 	// If an(y) error was encountered, it should be returned immediately,
 	// along with the number of bytes read up to that point.
-	Decode(from io.Reader, size int64) (n int, err error)
+	Decode(hash hash.Hash, from io.Reader, size int64) (n int, err error)
 
 	// Type returns the ObjectType constant that represents an instance of
 	// the implementing type.

--- a/object_db.go
+++ b/object_db.go
@@ -294,7 +294,7 @@ func (d *ObjectDatabase) encodeBuffer(object Object, buf io.ReadWriter) (sha []b
 	}
 	defer d.cleanup(tmp)
 
-	to := NewObjectWriter(tmp)
+	to := NewObjectWriter(tmp, d.Hasher())
 	if _, err = to.WriteHeader(object.Type(), int64(cn)); err != nil {
 		return nil, 0, err
 	}

--- a/object_db.go
+++ b/object_db.go
@@ -2,13 +2,16 @@ package gitobj
 
 import (
 	"bytes"
+	"crypto/sha1"
+	"crypto/sha256"
 	"fmt"
+	"hash"
 	"io"
 	"io/ioutil"
 	"os"
 	"sync/atomic"
 
-	"github.com/git-lfs/gitobj/storage"
+	"github.com/git-lfs/gitobj/v2/storage"
 )
 
 // ObjectDatabase enables the reading and writing of objects against a storage
@@ -29,41 +32,80 @@ type ObjectDatabase struct {
 
 	// temp directory, defaults to os.TempDir
 	tmp string
+
+	// objectFormat is the object format (hash algorithm)
+	objectFormat ObjectFormatAlgorithm
+}
+
+type options struct {
+	alternates   string
+	objectFormat ObjectFormatAlgorithm
+}
+
+type Option func(*options)
+
+type ObjectFormatAlgorithm string
+
+const (
+	ObjectFormatSHA1   = ObjectFormatAlgorithm("sha1")
+	ObjectFormatSHA256 = ObjectFormatAlgorithm("sha256")
+)
+
+// Alternates is an Option to specify the string of alternate repositories that
+// are searched for objects.  The format is the same as for
+// GIT_ALTERNATE_OBJECT_DIRECTORIES.
+func Alternates(alternates string) Option {
+	return func(args *options) {
+		args.alternates = alternates
+	}
+}
+
+// ObjectFormat is an Option to specify the hash algorithm (object format) in
+// use in Git.  If not specified, it defaults to ObjectFormatSHA1.
+func ObjectFormat(algo ObjectFormatAlgorithm) Option {
+	return func(args *options) {
+		args.objectFormat = algo
+	}
 }
 
 // FromFilesystem constructs an *ObjectDatabase instance that is backed by a
 // directory on the filesystem. Specifically, this should point to:
 //
 //  /absolute/repo/path/.git/objects
-func FromFilesystem(root, tmp string) (*ObjectDatabase, error) {
-	return FromFilesystemWithAlternates(root, tmp, "")
-}
+func FromFilesystem(root, tmp string, setters ...Option) (*ObjectDatabase, error) {
+	args := &options{objectFormat: ObjectFormatSHA1}
 
-// FromFilesystemWithAlternates constructs an *ObjectDatabase instance that is
-// backed by a directory on the filesystem, optionally with one or more
-// alternates. Specifically, this should point to:
-//
-//  /absolute/repo/path/.git/objects
-func FromFilesystemWithAlternates(root, tmp, alternates string) (*ObjectDatabase, error) {
-	b, err := NewFilesystemBackendWithAlternates(root, tmp, alternates)
+	for _, setter := range setters {
+		setter(args)
+	}
+
+	b, err := NewFilesystemBackendWithAlternates(root, tmp, args.alternates)
 	if err != nil {
 		return nil, err
 	}
 
-	ro, rw := b.Storage()
-	return &ObjectDatabase{
-		tmp: tmp,
-		ro:  ro,
-		rw:  rw,
-	}, nil
+	odb, err := FromBackend(b, setters...)
+	if err != nil {
+		return nil, err
+	}
+	odb.tmp = tmp
+	return odb, nil
 }
 
-func FromBackend(b storage.Backend) (*ObjectDatabase, error) {
+func FromBackend(b storage.Backend, setters ...Option) (*ObjectDatabase, error) {
+	args := &options{objectFormat: ObjectFormatSHA1}
+
+	for _, setter := range setters {
+		setter(args)
+	}
+
 	ro, rw := b.Storage()
-	return &ObjectDatabase{
-		ro: ro,
-		rw: rw,
-	}, nil
+	odb := &ObjectDatabase{
+		ro:           ro,
+		rw:           rw,
+		objectFormat: args.objectFormat,
+	}
+	return odb, nil
 }
 
 // Close closes the *ObjectDatabase, freeing any open resources (namely: the
@@ -227,6 +269,11 @@ func (o *ObjectDatabase) Root() (string, bool) {
 	return "", false
 }
 
+// Hasher returns a new hash instance suitable for this object database.
+func (o *ObjectDatabase) Hasher() hash.Hash {
+	return hasher(o.objectFormat)
+}
+
 // encode encodes and saves an object to the storage backend and uses an
 // in-memory buffer to calculate the object's encoded body.
 func (d *ObjectDatabase) encode(object Object) (sha []byte, n int64, err error) {
@@ -336,4 +383,15 @@ func (o *ObjectDatabase) decode(r *ObjectReader, into Object) error {
 func (o *ObjectDatabase) cleanup(f *os.File) {
 	f.Close()
 	os.Remove(f.Name())
+}
+
+func hasher(algo ObjectFormatAlgorithm) hash.Hash {
+	switch algo {
+	case ObjectFormatSHA1:
+		return sha1.New()
+	case ObjectFormatSHA256:
+		return sha256.New()
+	default:
+		return nil
+	}
 }

--- a/object_db.go
+++ b/object_db.go
@@ -79,7 +79,7 @@ func FromFilesystem(root, tmp string, setters ...Option) (*ObjectDatabase, error
 		setter(args)
 	}
 
-	b, err := NewFilesystemBackendWithAlternates(root, tmp, args.alternates)
+	b, err := NewFilesystemBackend(root, tmp, args.alternates, hasher(args.objectFormat))
 	if err != nil {
 		return nil, err
 	}

--- a/object_db.go
+++ b/object_db.go
@@ -370,7 +370,7 @@ func (o *ObjectDatabase) decode(r *ObjectReader, into Object) error {
 		return &UnexpectedObjectType{Got: typ, Wanted: into.Type()}
 	}
 
-	if _, err = into.Decode(r, size); err != nil {
+	if _, err = into.Decode(o.Hasher(), r, size); err != nil {
 		return err
 	}
 

--- a/object_db_test.go
+++ b/object_db_test.go
@@ -3,6 +3,7 @@ package gitobj
 import (
 	"bytes"
 	"compress/zlib"
+	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -270,6 +271,7 @@ func TestWriteCommitWithGPGSignature(t *testing.T) {
 
 	commit := new(Commit)
 	_, err = commit.Decode(
+		sha1.New(),
 		strings.NewReader(roundTripCommit), int64(len(roundTripCommit)))
 	require.NoError(t, err)
 

--- a/object_db_test.go
+++ b/object_db_test.go
@@ -55,211 +55,322 @@ handling more robust.
 `
 
 func TestDecodeObject(t *testing.T) {
-	sha := "af5626b4a114abcb82d63db7c8082c3c4756e51b"
-	contents := "Hello, world!\n"
+	testCases := []struct {
+		options []Option
+		sha     string
+	}{
+		{
+			[]Option{}, "af5626b4a114abcb82d63db7c8082c3c4756e51b",
+		},
+		{
+			[]Option{ObjectFormat(ObjectFormatSHA256)}, "7506cbcf4c572be9e06a1fed35ac5b1df8b5a74d26c07f022648e5d95a9f6f2a",
+		},
+	}
 
-	var buf bytes.Buffer
+	for _, test := range testCases {
+		contents := "Hello, world!\n"
 
-	zw := zlib.NewWriter(&buf)
-	fmt.Fprintf(zw, "blob 14\x00%s", contents)
-	zw.Close()
+		var buf bytes.Buffer
 
-	b, err := NewMemoryBackend(map[string]io.ReadWriter{
-		sha: &buf,
-	})
-	require.NoError(t, err)
+		zw := zlib.NewWriter(&buf)
+		fmt.Fprintf(zw, "blob 14\x00%s", contents)
+		zw.Close()
 
-	odb, err := FromBackend(b)
-	require.NoError(t, err)
+		b, err := NewMemoryBackend(map[string]io.ReadWriter{
+			test.sha: &buf,
+		})
+		require.NoError(t, err)
 
-	shaHex, _ := hex.DecodeString(sha)
-	obj, err := odb.Object(shaHex)
-	blob, ok := obj.(*Blob)
+		odb, err := FromBackend(b, test.options...)
+		require.NoError(t, err)
 
-	require.NoError(t, err)
-	require.True(t, ok)
+		shaHex, _ := hex.DecodeString(test.sha)
+		obj, err := odb.Object(shaHex)
+		blob, ok := obj.(*Blob)
 
-	got, err := ioutil.ReadAll(blob.Contents)
-	assert.Nil(t, err)
-	assert.Equal(t, contents, string(got))
+		require.NoError(t, err)
+		require.True(t, ok)
+
+		got, err := ioutil.ReadAll(blob.Contents)
+		assert.Nil(t, err)
+		assert.Equal(t, contents, string(got))
+	}
 }
 
 func TestDecodeBlob(t *testing.T) {
-	sha := "af5626b4a114abcb82d63db7c8082c3c4756e51b"
-	contents := "Hello, world!\n"
+	testCases := []struct {
+		options []Option
+		sha     string
+	}{
+		{
+			[]Option{}, "af5626b4a114abcb82d63db7c8082c3c4756e51b",
+		},
+		{
+			[]Option{ObjectFormat(ObjectFormatSHA256)}, "7506cbcf4c572be9e06a1fed35ac5b1df8b5a74d26c07f022648e5d95a9f6f2a",
+		},
+	}
 
-	var buf bytes.Buffer
+	for _, test := range testCases {
+		contents := "Hello, world!\n"
 
-	zw := zlib.NewWriter(&buf)
-	fmt.Fprintf(zw, "blob 14\x00%s", contents)
-	zw.Close()
+		var buf bytes.Buffer
 
-	b, err := NewMemoryBackend(map[string]io.ReadWriter{
-		sha: &buf,
-	})
-	require.NoError(t, err)
+		zw := zlib.NewWriter(&buf)
+		fmt.Fprintf(zw, "blob 14\x00%s", contents)
+		zw.Close()
 
-	odb, err := FromBackend(b)
-	require.NoError(t, err)
+		b, err := NewMemoryBackend(map[string]io.ReadWriter{
+			test.sha: &buf,
+		})
+		require.NoError(t, err)
 
-	shaHex, _ := hex.DecodeString(sha)
-	blob, err := odb.Blob(shaHex)
+		odb, err := FromBackend(b, test.options...)
+		require.NoError(t, err)
 
-	assert.Nil(t, err)
-	assert.EqualValues(t, 14, blob.Size)
+		shaHex, _ := hex.DecodeString(test.sha)
+		blob, err := odb.Blob(shaHex)
 
-	got, err := ioutil.ReadAll(blob.Contents)
-	assert.Nil(t, err)
-	assert.Equal(t, contents, string(got))
+		assert.Nil(t, err)
+		assert.EqualValues(t, 14, blob.Size)
+
+		got, err := ioutil.ReadAll(blob.Contents)
+		assert.Nil(t, err)
+		assert.Equal(t, contents, string(got))
+	}
 }
 
 func TestDecodeTree(t *testing.T) {
-	sha := "fcb545d5746547a597811b7441ed8eba307be1ff"
-	hexSha, err := hex.DecodeString(sha)
-	require.Nil(t, err)
-
-	blobSha := "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
-	hexBlobSha, err := hex.DecodeString(blobSha)
-	require.Nil(t, err)
-
-	var buf bytes.Buffer
-
-	zw := zlib.NewWriter(&buf)
-	fmt.Fprintf(zw, "tree 37\x00")
-	fmt.Fprintf(zw, "100644 hello.txt\x00")
-	zw.Write(hexBlobSha)
-	zw.Close()
-
-	b, err := NewMemoryBackend(map[string]io.ReadWriter{
-		sha: &buf,
-	})
-	require.NoError(t, err)
-
-	odb, err := FromBackend(b)
-	require.NoError(t, err)
-
-	tree, err := odb.Tree(hexSha)
-
-	assert.Nil(t, err)
-	require.Equal(t, 1, len(tree.Entries))
-	assert.Equal(t, &TreeEntry{
-		Name:     "hello.txt",
-		Oid:      hexBlobSha,
-		Filemode: 0100644,
-	}, tree.Entries[0])
-}
-
-func TestDecodeCommit(t *testing.T) {
-	sha := "d7283480bb6dc90be621252e1001a93871dcf511"
-	commitShaHex, err := hex.DecodeString(sha)
-	assert.Nil(t, err)
-
-	var buf bytes.Buffer
-
-	zw := zlib.NewWriter(&buf)
-	fmt.Fprintf(zw, "commit 173\x00")
-	fmt.Fprintf(zw, "tree fcb545d5746547a597811b7441ed8eba307be1ff\n")
-	fmt.Fprintf(zw, "author Taylor Blau <me@ttaylorr.com> 1494620424 -0600\n")
-	fmt.Fprintf(zw, "committer Taylor Blau <me@ttaylorr.com> 1494620424 -0600\n")
-	fmt.Fprintf(zw, "\ninitial commit\n")
-	zw.Close()
-
-	b, err := NewMemoryBackend(map[string]io.ReadWriter{
-		sha: &buf,
-	})
-	require.NoError(t, err)
-
-	odb, err := FromBackend(b)
-	require.NoError(t, err)
-
-	commit, err := odb.Commit(commitShaHex)
-
-	assert.Nil(t, err)
-	assert.Equal(t, "Taylor Blau <me@ttaylorr.com> 1494620424 -0600", commit.Author)
-	assert.Equal(t, "Taylor Blau <me@ttaylorr.com> 1494620424 -0600", commit.Committer)
-	assert.Equal(t, "initial commit", commit.Message)
-	assert.Equal(t, 0, len(commit.ParentIDs))
-	assert.Equal(t, "fcb545d5746547a597811b7441ed8eba307be1ff", hex.EncodeToString(commit.TreeID))
-}
-
-func TestWriteBlob(t *testing.T) {
-	b, err := NewMemoryBackend(nil)
-	require.NoError(t, err)
-
-	odb, err := FromBackend(b)
-	require.NoError(t, err)
-
-	sha, err := odb.WriteBlob(&Blob{
-		Size:     14,
-		Contents: strings.NewReader("Hello, world!\n"),
-	})
-
-	expected := "af5626b4a114abcb82d63db7c8082c3c4756e51b"
-
-	_, s := b.Storage()
-
-	assert.Nil(t, err)
-	assert.Equal(t, expected, hex.EncodeToString(sha))
-	assert.NotNil(t, s.(*memoryStorer).fs[hex.EncodeToString(sha)])
-}
-
-func TestWriteTree(t *testing.T) {
-	b, err := NewMemoryBackend(nil)
-	require.NoError(t, err)
-
-	odb, err := FromBackend(b)
-	require.NoError(t, err)
-
-	blobSha := "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
-	hexBlobSha, err := hex.DecodeString(blobSha)
-	require.Nil(t, err)
-
-	sha, err := odb.WriteTree(&Tree{Entries: []*TreeEntry{
+	testCases := []struct {
+		options []Option
+		size    int64
+		treeSha string
+		blobSha string
+	}{
 		{
+			[]Option{},
+			37,
+			"fcb545d5746547a597811b7441ed8eba307be1ff",
+			"e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+		},
+		{
+			[]Option{ObjectFormat(ObjectFormatSHA256)},
+			49,
+			"eeea12da3c10b7ff20f96530ca613674f0b3292cb524c1b317b80e045adde0b6",
+			"473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813",
+		},
+	}
+
+	for _, test := range testCases {
+		hexSha, err := hex.DecodeString(test.treeSha)
+		require.Nil(t, err)
+
+		hexBlobSha, err := hex.DecodeString(test.blobSha)
+		require.Nil(t, err)
+
+		var buf bytes.Buffer
+
+		zw := zlib.NewWriter(&buf)
+		fmt.Fprintf(zw, "tree %d\x00", test.size)
+		fmt.Fprintf(zw, "100644 hello.txt\x00")
+		zw.Write(hexBlobSha)
+		zw.Close()
+
+		b, err := NewMemoryBackend(map[string]io.ReadWriter{
+			test.treeSha: &buf,
+		})
+		require.NoError(t, err)
+
+		odb, err := FromBackend(b, test.options...)
+		require.NoError(t, err)
+
+		tree, err := odb.Tree(hexSha)
+
+		assert.Nil(t, err)
+		require.Equal(t, 1, len(tree.Entries))
+		assert.Equal(t, &TreeEntry{
 			Name:     "hello.txt",
 			Oid:      hexBlobSha,
 			Filemode: 0100644,
+		}, tree.Entries[0])
+	}
+}
+
+func TestDecodeCommit(t *testing.T) {
+	testCases := []struct {
+		options   []Option
+		size      int64
+		treeSha   string
+		commitSha string
+	}{
+		{
+			[]Option{},
+			173,
+			"fcb545d5746547a597811b7441ed8eba307be1ff",
+			"d7283480bb6dc90be621252e1001a93871dcf511",
 		},
-	}})
+		{
+			[]Option{ObjectFormat(ObjectFormatSHA256)},
+			197,
+			"eeea12da3c10b7ff20f96530ca613674f0b3292cb524c1b317b80e045adde0b6",
+			"9b03a791a98a2c35621ea6870061fb17299b22e2bb5e9f6a7d5afd7dc0c23915",
+		},
+	}
 
-	expected := "fcb545d5746547a597811b7441ed8eba307be1ff"
+	for _, test := range testCases {
+		commitShaHex, err := hex.DecodeString(test.commitSha)
+		assert.Nil(t, err)
 
-	_, s := b.Storage()
+		var buf bytes.Buffer
 
-	assert.Nil(t, err)
-	assert.Equal(t, expected, hex.EncodeToString(sha))
-	assert.NotNil(t, s.(*memoryStorer).fs[hex.EncodeToString(sha)])
+		zw := zlib.NewWriter(&buf)
+		fmt.Fprintf(zw, "commit %d\x00", test.size)
+		fmt.Fprintf(zw, "tree %s\n", test.treeSha)
+		fmt.Fprintf(zw, "author Taylor Blau <me@ttaylorr.com> 1494620424 -0600\n")
+		fmt.Fprintf(zw, "committer Taylor Blau <me@ttaylorr.com> 1494620424 -0600\n")
+		fmt.Fprintf(zw, "\ninitial commit\n")
+		zw.Close()
+
+		b, err := NewMemoryBackend(map[string]io.ReadWriter{
+			test.commitSha: &buf,
+		})
+		require.NoError(t, err)
+
+		odb, err := FromBackend(b, test.options...)
+		require.NoError(t, err)
+
+		commit, err := odb.Commit(commitShaHex)
+
+		assert.Nil(t, err)
+		assert.Equal(t, "Taylor Blau <me@ttaylorr.com> 1494620424 -0600", commit.Author)
+		assert.Equal(t, "Taylor Blau <me@ttaylorr.com> 1494620424 -0600", commit.Committer)
+		assert.Equal(t, "initial commit", commit.Message)
+		assert.Equal(t, 0, len(commit.ParentIDs))
+		assert.Equal(t, test.treeSha, hex.EncodeToString(commit.TreeID))
+	}
+}
+
+func TestWriteBlob(t *testing.T) {
+	testCases := []struct {
+		options []Option
+		sha     string
+	}{
+		{
+			[]Option{}, "af5626b4a114abcb82d63db7c8082c3c4756e51b",
+		},
+		{
+			[]Option{ObjectFormat(ObjectFormatSHA256)}, "7506cbcf4c572be9e06a1fed35ac5b1df8b5a74d26c07f022648e5d95a9f6f2a",
+		},
+	}
+
+	for _, test := range testCases {
+		b, err := NewMemoryBackend(nil)
+		require.NoError(t, err)
+
+		odb, err := FromBackend(b, test.options...)
+		require.NoError(t, err)
+
+		sha, err := odb.WriteBlob(&Blob{
+			Size:     14,
+			Contents: strings.NewReader("Hello, world!\n"),
+		})
+
+		_, s := b.Storage()
+
+		assert.Nil(t, err)
+		assert.Equal(t, test.sha, hex.EncodeToString(sha))
+		assert.NotNil(t, s.(*memoryStorer).fs[hex.EncodeToString(sha)])
+	}
+}
+
+func TestWriteTree(t *testing.T) {
+	testCases := []struct {
+		options []Option
+		treeSha string
+		blobSha string
+	}{
+		{
+			[]Option{},
+			"fcb545d5746547a597811b7441ed8eba307be1ff",
+			"e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+		},
+		{
+			[]Option{ObjectFormat(ObjectFormatSHA256)},
+			"eeea12da3c10b7ff20f96530ca613674f0b3292cb524c1b317b80e045adde0b6",
+			"473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813",
+		},
+	}
+
+	for _, test := range testCases {
+		b, err := NewMemoryBackend(nil)
+		require.NoError(t, err)
+
+		odb, err := FromBackend(b, test.options...)
+		require.NoError(t, err)
+
+		hexBlobSha, err := hex.DecodeString(test.blobSha)
+		require.Nil(t, err)
+
+		sha, err := odb.WriteTree(&Tree{Entries: []*TreeEntry{
+			{
+				Name:     "hello.txt",
+				Oid:      hexBlobSha,
+				Filemode: 0100644,
+			},
+		}})
+
+		_, s := b.Storage()
+
+		assert.Nil(t, err)
+		assert.Equal(t, test.treeSha, hex.EncodeToString(sha))
+		assert.NotNil(t, s.(*memoryStorer).fs[hex.EncodeToString(sha)])
+	}
 }
 
 func TestWriteCommit(t *testing.T) {
-	b, err := NewMemoryBackend(nil)
-	require.NoError(t, err)
+	testCases := []struct {
+		options   []Option
+		treeSha   string
+		commitSha string
+	}{
+		{
+			[]Option{},
+			"fcb545d5746547a597811b7441ed8eba307be1ff",
+			"fee8a35c2890cd6e0e28d24cc457fcecbd460962",
+		},
+		{
+			[]Option{ObjectFormat(ObjectFormatSHA256)},
+			"eeea12da3c10b7ff20f96530ca613674f0b3292cb524c1b317b80e045adde0b6",
+			"fcafabe9e00f4e1375b2ba688edf30b96afe7a20c6176fefbc3f371b298f69d6",
+		},
+	}
 
-	odb, err := FromBackend(b)
-	require.NoError(t, err)
+	for _, test := range testCases {
+		b, err := NewMemoryBackend(nil)
+		require.NoError(t, err)
 
-	when := time.Unix(1257894000, 0).UTC()
-	author := &Signature{Name: "John Doe", Email: "john@example.com", When: when}
-	committer := &Signature{Name: "Jane Doe", Email: "jane@example.com", When: when}
+		odb, err := FromBackend(b, test.options...)
+		require.NoError(t, err)
 
-	tree := "fcb545d5746547a597811b7441ed8eba307be1ff"
-	treeHex, err := hex.DecodeString(tree)
-	assert.Nil(t, err)
+		when := time.Unix(1257894000, 0).UTC()
+		author := &Signature{Name: "John Doe", Email: "john@example.com", When: when}
+		committer := &Signature{Name: "Jane Doe", Email: "jane@example.com", When: when}
 
-	sha, err := odb.WriteCommit(&Commit{
-		Author:    author.String(),
-		Committer: committer.String(),
-		TreeID:    treeHex,
-		Message:   "initial commit",
-	})
+		treeHex, err := hex.DecodeString(test.treeSha)
+		assert.Nil(t, err)
 
-	expected := "fee8a35c2890cd6e0e28d24cc457fcecbd460962"
+		sha, err := odb.WriteCommit(&Commit{
+			Author:    author.String(),
+			Committer: committer.String(),
+			TreeID:    treeHex,
+			Message:   "initial commit",
+		})
 
-	_, s := b.Storage()
+		_, s := b.Storage()
 
-	assert.Nil(t, err)
-	assert.Equal(t, expected, hex.EncodeToString(sha))
-	assert.NotNil(t, s.(*memoryStorer).fs[hex.EncodeToString(sha)])
+		assert.Nil(t, err)
+		assert.Equal(t, test.commitSha, hex.EncodeToString(sha))
+		assert.NotNil(t, s.(*memoryStorer).fs[hex.EncodeToString(sha)])
+	}
 }
 
 func TestWriteCommitWithGPGSignature(t *testing.T) {
@@ -321,28 +432,45 @@ func TestDecodeTag(t *testing.T) {
 }
 
 func TestWriteTag(t *testing.T) {
-	b, err := NewMemoryBackend(nil)
-	require.NoError(t, err)
+	testCases := []struct {
+		options   []Option
+		tagSha    string
+		commitSha []byte
+	}{
+		{
+			[]Option{},
+			"e614dda21829f4176d3db27fe62fb4aee2e2475d",
+			[]byte("aaaaaaaaaaaaaaaaaaaa"),
+		},
+		{
+			[]Option{ObjectFormat(ObjectFormatSHA256)},
+			"a297d8b92e8be21fbe1c96a64acc596f26c8b204eb291c71e371c832d3584651",
+			[]byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+		},
+	}
 
-	odb, err := FromBackend(b)
-	require.NoError(t, err)
+	for _, test := range testCases {
+		b, err := NewMemoryBackend(nil)
+		require.NoError(t, err)
 
-	sha, err := odb.WriteTag(&Tag{
-		Object:     []byte("aaaaaaaaaaaaaaaaaaaa"),
-		ObjectType: CommitObjectType,
-		Name:       "v2.4.0",
-		Tagger:     "A U Thor <author@example.com>",
+		odb, err := FromBackend(b, test.options...)
+		require.NoError(t, err)
 
-		Message: "The quick brown fox jumps over the lazy dog.",
-	})
+		sha, err := odb.WriteTag(&Tag{
+			Object:     test.commitSha,
+			ObjectType: CommitObjectType,
+			Name:       "v2.4.0",
+			Tagger:     "A U Thor <author@example.com>",
 
-	expected := "e614dda21829f4176d3db27fe62fb4aee2e2475d"
+			Message: "The quick brown fox jumps over the lazy dog.",
+		})
 
-	_, s := b.Storage()
+		_, s := b.Storage()
 
-	assert.Nil(t, err)
-	assert.Equal(t, expected, hex.EncodeToString(sha))
-	assert.NotNil(t, s.(*memoryStorer).fs[hex.EncodeToString(sha)])
+		assert.Nil(t, err)
+		assert.Equal(t, test.tagSha, hex.EncodeToString(sha))
+		assert.NotNil(t, s.(*memoryStorer).fs[hex.EncodeToString(sha)])
+	}
 }
 
 func TestReadingAMissingObjectAfterClose(t *testing.T) {

--- a/object_writer.go
+++ b/object_writer.go
@@ -2,7 +2,6 @@ package gitobj
 
 import (
 	"compress/zlib"
-	"crypto/sha1"
 	"fmt"
 	"hash"
 	"io"
@@ -50,18 +49,20 @@ func (n *nopCloser) Close() error {
 }
 
 // NewObjectWriter returns a new *ObjectWriter instance that drains incoming
-// writes into the io.Writer given, "w".
-func NewObjectWriter(w io.Writer) *ObjectWriter {
-	return NewObjectWriteCloser(&nopCloser{w})
+// writes into the io.Writer given, "w".  "hash" is a hash instance from the
+// ObjectDatabase'e Hash method.
+func NewObjectWriter(w io.Writer, hash hash.Hash) *ObjectWriter {
+	return NewObjectWriteCloser(&nopCloser{w}, hash)
 }
 
 // NewObjectWriter returns a new *ObjectWriter instance that drains incoming
-// writes into the io.Writer given, "w".
+// writes into the io.Writer given, "w".  "sum" is a hash instance from the
+// ObjectDatabase'e Hash method.
 //
 // Upon closing, it calls the given Close() function of the io.WriteCloser.
-func NewObjectWriteCloser(w io.WriteCloser) *ObjectWriter {
+func NewObjectWriteCloser(w io.WriteCloser, sum hash.Hash) *ObjectWriter {
 	zw := zlib.NewWriter(w)
-	sum := sha1.New()
+	sum.Reset()
 
 	return &ObjectWriter{
 		w:   io.MultiWriter(zw, sum),

--- a/object_writer_test.go
+++ b/object_writer_test.go
@@ -3,8 +3,11 @@ package gitobj
 import (
 	"bytes"
 	"compress/zlib"
+	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"hash"
 	"io"
 	"io/ioutil"
 	"sync/atomic"
@@ -16,7 +19,7 @@ import (
 func TestObjectWriterWritesHeaders(t *testing.T) {
 	var buf bytes.Buffer
 
-	w := NewObjectWriter(&buf)
+	w := NewObjectWriter(&buf, sha1.New())
 
 	n, err := w.WriteHeader(BlobObjectType, 1)
 	assert.Equal(t, 7, n)
@@ -35,25 +38,40 @@ func TestObjectWriterWritesHeaders(t *testing.T) {
 }
 
 func TestObjectWriterWritesData(t *testing.T) {
-	var buf bytes.Buffer
+	testCases := []struct {
+		h   hash.Hash
+		sha string
+	}{
+		{
+			sha1.New(), "56a6051ca2b02b04ef92d5150c9ef600403cb1de",
+		},
+		{
+			sha256.New(), "36456d9b87f21fc54ed5babf1222a9ab0fbbd0c4ad239a7933522d5e4447049c",
+		},
+	}
 
-	w := NewObjectWriter(&buf)
-	w.WriteHeader(BlobObjectType, 1)
+	for _, test := range testCases {
+		var buf bytes.Buffer
 
-	n, err := w.Write([]byte{0x31})
-	assert.Equal(t, 1, n)
-	assert.Nil(t, err)
+		w := NewObjectWriter(&buf, test.h)
+		w.WriteHeader(BlobObjectType, 1)
 
-	assert.Nil(t, w.Close())
+		n, err := w.Write([]byte{0x31})
+		assert.Equal(t, 1, n)
+		assert.Nil(t, err)
 
-	r, err := zlib.NewReader(&buf)
-	assert.Nil(t, err)
+		assert.Nil(t, w.Close())
 
-	all, err := ioutil.ReadAll(r)
-	assert.Nil(t, err)
-	assert.Equal(t, []byte("blob 1\x001"), all)
+		r, err := zlib.NewReader(&buf)
+		assert.Nil(t, err)
 
-	assert.Nil(t, r.Close())
+		all, err := ioutil.ReadAll(r)
+		assert.Nil(t, err)
+		assert.Equal(t, []byte("blob 1\x001"), all)
+
+		assert.Nil(t, r.Close())
+		assert.Equal(t, test.sha, hex.EncodeToString(w.Sha()))
+	}
 }
 
 func TestObjectWriterPanicsOnWritesWithoutHeader(t *testing.T) {
@@ -64,7 +82,7 @@ func TestObjectWriterPanicsOnWritesWithoutHeader(t *testing.T) {
 		assert.Equal(t, "gitobj: cannot write data without header", err)
 	}()
 
-	w := NewObjectWriter(new(bytes.Buffer))
+	w := NewObjectWriter(new(bytes.Buffer), sha1.New())
 	w.Write(nil)
 }
 
@@ -76,19 +94,27 @@ func TestObjectWriterPanicsOnMultipleHeaderWrites(t *testing.T) {
 		assert.Equal(t, "gitobj: cannot write headers more than once", err)
 	}()
 
-	w := NewObjectWriter(new(bytes.Buffer))
+	w := NewObjectWriter(new(bytes.Buffer), sha1.New())
 	w.WriteHeader(BlobObjectType, 1)
 	w.WriteHeader(TreeObjectType, 2)
 }
 
 func TestObjectWriterKeepsTrackOfHash(t *testing.T) {
-	w := NewObjectWriter(new(bytes.Buffer))
+	w := NewObjectWriter(new(bytes.Buffer), sha1.New())
 	n, err := w.WriteHeader(BlobObjectType, 1)
 
 	assert.Nil(t, err)
 	assert.Equal(t, 7, n)
 
 	assert.Equal(t, "bb6ca78b66403a67c6281df142de5ef472186283", hex.EncodeToString(w.Sha()))
+
+	w = NewObjectWriter(new(bytes.Buffer), sha256.New())
+	n, err = w.WriteHeader(BlobObjectType, 1)
+
+	assert.Nil(t, err)
+	assert.Equal(t, 7, n)
+
+	assert.Equal(t, "3a68c454a6eb75cc55bda147a53756f0f581497eb80b9b67156fb8a8d3931cd7", hex.EncodeToString(w.Sha()))
 }
 
 type WriteCloserFn struct {
@@ -109,7 +135,7 @@ func TestObjectWriterCallsClose(t *testing.T) {
 			atomic.AddUint32(&calls, 1)
 			return expected
 		},
-	})
+	}, sha1.New())
 
 	got := w.Close()
 

--- a/pack/index.go
+++ b/pack/index.go
@@ -2,9 +2,12 @@ package pack
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"fmt"
 	"io"
 )
+
+const maxHashSize = sha256.Size
 
 // Index stores information about the location of objects in a corresponding
 // packfile.

--- a/pack/index_decode.go
+++ b/pack/index_decode.go
@@ -34,8 +34,6 @@ const (
 	// V2 header.
 	indexOffsetV2Start = indexV2Width + indexFanoutWidth
 
-	// indexObjectNameWidth is the width of a SHA1 object name.
-	indexObjectNameWidth = 20
 	// indexObjectCRCWidth is the width of the CRC accompanying each object
 	// in V2.
 	indexObjectCRCWidth = 4
@@ -45,13 +43,6 @@ const (
 	// indexObjectLargeOffsetWidth is the width of the optional large offset
 	// encoded into the small offset.
 	indexObjectLargeOffsetWidth = 8
-
-	// indexObjectEntryV1Width is the width of one contiguous object entry
-	// in V1.
-	indexObjectEntryV1Width = indexObjectNameWidth + indexObjectSmallOffsetWidth
-	// indexObjectEntryV2Width is the width of one non-contiguous object
-	// entry in V2.
-	indexObjectEntryV2Width = indexObjectNameWidth + indexObjectCRCWidth + indexObjectSmallOffsetWidth
 )
 
 var (

--- a/pack/index_decode.go
+++ b/pack/index_decode.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"hash"
 	"io"
 )
 
@@ -69,8 +70,8 @@ var (
 // parse index entries.
 //
 // If there was an error parsing, it will be returned immediately.
-func DecodeIndex(r io.ReaderAt) (*Index, error) {
-	version, err := decodeIndexHeader(r)
+func DecodeIndex(r io.ReaderAt, hash hash.Hash) (*Index, error) {
+	version, err := decodeIndexHeader(r, hash)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +90,7 @@ func DecodeIndex(r io.ReaderAt) (*Index, error) {
 }
 
 // decodeIndexHeader determines which version the index given by "r" is.
-func decodeIndexHeader(r io.ReaderAt) (IndexVersion, error) {
+func decodeIndexHeader(r io.ReaderAt, hash hash.Hash) (IndexVersion, error) {
 	hdr := make([]byte, 4)
 	if _, err := r.ReadAt(hdr, 0); err != nil {
 		return nil, err
@@ -104,13 +105,13 @@ func decodeIndexHeader(r io.ReaderAt) (IndexVersion, error) {
 		version := binary.BigEndian.Uint32(vb)
 		switch version {
 		case 1:
-			return new(V1), nil
+			return &V1{hash: hash}, nil
 		case 2:
-			return new(V2), nil
+			return &V2{hash: hash}, nil
 		}
 		return nil, &UnsupportedVersionErr{uint32(version)}
 	}
-	return new(V1), nil
+	return &V1{hash: hash}, nil
 }
 
 // decodeIndexFanout decodes the fanout table given by "r" and beginning at the

--- a/pack/index_decode_test.go
+++ b/pack/index_decode_test.go
@@ -2,6 +2,7 @@ package pack
 
 import (
 	"bytes"
+	"crypto/sha1"
 	"encoding/binary"
 	"io"
 	"testing"
@@ -21,7 +22,7 @@ func TestDecodeIndexV2(t *testing.T) {
 		buf = append(buf, x...)
 	}
 
-	idx, err := DecodeIndex(bytes.NewReader(buf))
+	idx, err := DecodeIndex(bytes.NewReader(buf), sha1.New())
 
 	assert.NoError(t, err)
 	assert.EqualValues(t, 3, idx.Count())
@@ -33,21 +34,21 @@ func TestDecodeIndexV2InvalidFanout(t *testing.T) {
 	buf = append(buf, 0x0, 0x0, 0x0, 0x2)
 	buf = append(buf, make([]byte, indexFanoutWidth-1)...)
 
-	idx, err := DecodeIndex(bytes.NewReader(buf))
+	idx, err := DecodeIndex(bytes.NewReader(buf), sha1.New())
 
 	assert.Equal(t, ErrShortFanout, err)
 	assert.Nil(t, idx)
 }
 
 func TestDecodeIndexV1(t *testing.T) {
-	idx, err := DecodeIndex(bytes.NewReader(make([]byte, indexFanoutWidth)))
+	idx, err := DecodeIndex(bytes.NewReader(make([]byte, indexFanoutWidth)), sha1.New())
 
 	assert.NoError(t, err)
 	assert.EqualValues(t, 0, idx.Count())
 }
 
 func TestDecodeIndexV1InvalidFanout(t *testing.T) {
-	idx, err := DecodeIndex(bytes.NewReader(make([]byte, indexFanoutWidth-1)))
+	idx, err := DecodeIndex(bytes.NewReader(make([]byte, indexFanoutWidth-1)), sha1.New())
 
 	assert.Equal(t, ErrShortFanout, err)
 	assert.Nil(t, idx)
@@ -58,14 +59,14 @@ func TestDecodeIndexUnsupportedVersion(t *testing.T) {
 	buf = append(buf, 0xff, 0x74, 0x4f, 0x63)
 	buf = append(buf, 0x0, 0x0, 0x0, 0x3)
 
-	idx, err := DecodeIndex(bytes.NewReader(buf))
+	idx, err := DecodeIndex(bytes.NewReader(buf), sha1.New())
 
 	assert.EqualError(t, err, "gitobj/pack: unsupported version: 3")
 	assert.Nil(t, idx)
 }
 
 func TestDecodeIndexEmptyContents(t *testing.T) {
-	idx, err := DecodeIndex(bytes.NewReader(make([]byte, 0)))
+	idx, err := DecodeIndex(bytes.NewReader(make([]byte, 0)), sha1.New())
 
 	assert.Equal(t, io.EOF, err)
 	assert.Nil(t, idx)

--- a/pack/index_test.go
+++ b/pack/index_test.go
@@ -2,6 +2,7 @@ package pack
 
 import (
 	"bytes"
+	"crypto/sha1"
 	"encoding/binary"
 	"fmt"
 	"testing"
@@ -165,7 +166,7 @@ func init() {
 		fanout: fanout,
 		// version is unimportant here, use V2 since it's more common in
 		// the wild.
-		version: new(V2),
+		version: &V2{hash: sha1.New()},
 
 		// *bytes.Buffer does not implement io.ReaderAt, but
 		// *bytes.Reader does.

--- a/pack/index_v1.go
+++ b/pack/index_v1.go
@@ -2,10 +2,13 @@ package pack
 
 import (
 	"encoding/binary"
+	"hash"
 )
 
 // V1 implements IndexVersion for v1 packfiles.
-type V1 struct{}
+type V1 struct {
+	hash hash.Hash
+}
 
 // Name implements IndexVersion.Name by returning the 20 byte SHA-1 object name
 // for the given entry at offset "at" in the v1 index file "idx".

--- a/pack/index_v1.go
+++ b/pack/index_v1.go
@@ -13,19 +13,22 @@ type V1 struct {
 // Name implements IndexVersion.Name by returning the 20 byte SHA-1 object name
 // for the given entry at offset "at" in the v1 index file "idx".
 func (v *V1) Name(idx *Index, at int64) ([]byte, error) {
-	var sha [20]byte
-	if _, err := idx.readAt(sha[:], v1ShaOffset(at)); err != nil {
+	var sha [maxHashSize]byte
+
+	hashlen := v.hash.Size()
+
+	if _, err := idx.readAt(sha[:hashlen], v1ShaOffset(at, int64(hashlen))); err != nil {
 		return nil, err
 	}
 
-	return sha[:], nil
+	return sha[:hashlen], nil
 }
 
 // Entry implements IndexVersion.Entry for v1 packfiles by parsing and returning
 // the IndexEntry specified at the offset "at" in the given index file.
 func (v *V1) Entry(idx *Index, at int64) (*IndexEntry, error) {
 	var offs [4]byte
-	if _, err := idx.readAt(offs[:], v1EntryOffset(at)); err != nil {
+	if _, err := idx.readAt(offs[:], v1EntryOffset(at, int64(v.hash.Size()))); err != nil {
 		return nil, err
 	}
 
@@ -41,9 +44,9 @@ func (v *V1) Width() int64 {
 }
 
 // v1ShaOffset returns the location of the SHA1 of an object given at "at".
-func v1ShaOffset(at int64) int64 {
+func v1ShaOffset(at int64, hashlen int64) int64 {
 	// Skip forward until the desired entry.
-	return v1EntryOffset(at) +
+	return v1EntryOffset(at, hashlen) +
 		// Skip past the 4-byte object offset in the desired entry to
 		// the SHA1.
 		indexObjectSmallOffsetWidth
@@ -51,9 +54,9 @@ func v1ShaOffset(at int64) int64 {
 
 // v1EntryOffset returns the location of the packfile offset for the object
 // given at "at".
-func v1EntryOffset(at int64) int64 {
+func v1EntryOffset(at int64, hashlen int64) int64 {
 	// Skip the L1 fanout table
 	return indexOffsetV1Start +
 		// Skip the object entries before the one located at "at"
-		(indexObjectEntryV1Width * at)
+		((hashlen + indexObjectSmallOffsetWidth) * at)
 }

--- a/pack/index_v1_test.go
+++ b/pack/index_v1_test.go
@@ -2,6 +2,7 @@ package pack
 
 import (
 	"bytes"
+	"crypto/sha1"
 	"encoding/binary"
 	"testing"
 
@@ -37,19 +38,21 @@ var (
 
 	V1Index = &Index{
 		fanout:  V1IndexFanout,
-		version: new(V1),
+		version: &V1{hash: sha1.New()},
 	}
 )
 
 func TestIndexV1SearchExact(t *testing.T) {
-	e, err := new(V1).Entry(V1Index, 1)
+	v := &V1{hash: sha1.New()}
+	e, err := v.Entry(V1Index, 1)
 
 	assert.NoError(t, err)
 	assert.EqualValues(t, 2, e.PackOffset)
 }
 
 func TestIndexVersionWidthV1(t *testing.T) {
-	assert.EqualValues(t, 0, new(V1).Width())
+	v := &V1{hash: sha1.New()}
+	assert.EqualValues(t, 0, v.Width())
 }
 
 func init() {

--- a/pack/index_v2.go
+++ b/pack/index_v2.go
@@ -13,19 +13,25 @@ type V2 struct {
 // Name implements IndexVersion.Name by returning the 20 byte SHA-1 object name
 // for the given entry at offset "at" in the v2 index file "idx".
 func (v *V2) Name(idx *Index, at int64) ([]byte, error) {
-	var sha [20]byte
-	if _, err := idx.readAt(sha[:], v2ShaOffset(at)); err != nil {
+	var sha [maxHashSize]byte
+
+	hashlen := v.hash.Size()
+
+	if _, err := idx.readAt(sha[:hashlen], v2ShaOffset(at, int64(hashlen))); err != nil {
 		return nil, err
 	}
 
-	return sha[:], nil
+	return sha[:hashlen], nil
 }
 
 // Entry implements IndexVersion.Entry for v2 packfiles by parsing and returning
 // the IndexEntry specified at the offset "at" in the given index file.
 func (v *V2) Entry(idx *Index, at int64) (*IndexEntry, error) {
 	var offs [4]byte
-	if _, err := idx.readAt(offs[:], v2SmallOffsetOffset(at, int64(idx.Count()))); err != nil {
+
+	hashlen := v.hash.Size()
+
+	if _, err := idx.readAt(offs[:], v2SmallOffsetOffset(at, int64(idx.Count()), int64(hashlen))); err != nil {
 		return nil, err
 	}
 
@@ -36,7 +42,7 @@ func (v *V2) Entry(idx *Index, at int64) (*IndexEntry, error) {
 		//
 		// Mask away (offs&0x7fffffff) the MSB to use as an index to
 		// find the offset of the 8-byte pack offset.
-		lo := v2LargeOffsetOffset(int64(loc&0x7fffffff), int64(idx.Count()))
+		lo := v2LargeOffsetOffset(int64(loc&0x7fffffff), int64(idx.Count()), int64(hashlen))
 
 		var offs [8]byte
 		if _, err := idx.readAt(offs[:], lo); err != nil {
@@ -55,20 +61,20 @@ func (v *V2) Width() int64 {
 }
 
 // v2ShaOffset returns the offset of a SHA1 given at "at" in the V2 index file.
-func v2ShaOffset(at int64) int64 {
+func v2ShaOffset(at int64, hashlen int64) int64 {
 	// Skip the packfile index header and the L1 fanout table.
 	return indexOffsetV2Start +
 		// Skip until the desired name in the sorted names table.
-		(indexObjectNameWidth * at)
+		(hashlen * at)
 }
 
 // v2SmallOffsetOffset returns the offset of an object's small (4-byte) offset
 // given by "at".
-func v2SmallOffsetOffset(at, total int64) int64 {
+func v2SmallOffsetOffset(at, total, hashlen int64) int64 {
 	// Skip the packfile index header and the L1 fanout table.
 	return indexOffsetV2Start +
 		// Skip the name table.
-		(indexObjectNameWidth * total) +
+		(hashlen * total) +
 		// Skip the CRC table.
 		(indexObjectCRCWidth * total) +
 		// Skip until the desired index in the small offsets table.
@@ -77,11 +83,11 @@ func v2SmallOffsetOffset(at, total int64) int64 {
 
 // v2LargeOffsetOffset returns the offset of an object's large (4-byte) offset,
 // given by the index "at".
-func v2LargeOffsetOffset(at, total int64) int64 {
+func v2LargeOffsetOffset(at, total, hashlen int64) int64 {
 	// Skip the packfile index header and the L1 fanout table.
 	return indexOffsetV2Start +
 		// Skip the name table.
-		(indexObjectNameWidth * total) +
+		(hashlen * total) +
 		// Skip the CRC table.
 		(indexObjectCRCWidth * total) +
 		// Skip the small offsets table.

--- a/pack/index_v2.go
+++ b/pack/index_v2.go
@@ -2,10 +2,13 @@ package pack
 
 import (
 	"encoding/binary"
+	"hash"
 )
 
 // V2 implements IndexVersion for v2 packfiles.
-type V2 struct{}
+type V2 struct {
+	hash hash.Hash
+}
 
 // Name implements IndexVersion.Name by returning the 20 byte SHA-1 object name
 // for the given entry at offset "at" in the v2 index file "idx".

--- a/pack/index_v2_test.go
+++ b/pack/index_v2_test.go
@@ -2,6 +2,7 @@ package pack
 
 import (
 	"bytes"
+	"crypto/sha1"
 	"encoding/binary"
 	"testing"
 
@@ -46,26 +47,29 @@ var (
 
 	V2Index = &Index{
 		fanout:  V2IndexFanout,
-		version: new(V2),
+		version: &V2{hash: sha1.New()},
 	}
 )
 
 func TestIndexV2EntryExact(t *testing.T) {
-	e, err := new(V2).Entry(V2Index, 1)
+	v := &V2{hash: sha1.New()}
+	e, err := v.Entry(V2Index, 1)
 
 	assert.NoError(t, err)
 	assert.EqualValues(t, 2, e.PackOffset)
 }
 
 func TestIndexV2EntryExtendedOffset(t *testing.T) {
-	e, err := new(V2).Entry(V2Index, 2)
+	v := &V2{hash: sha1.New()}
+	e, err := v.Entry(V2Index, 2)
 
 	assert.NoError(t, err)
 	assert.EqualValues(t, 3, e.PackOffset)
 }
 
 func TestIndexVersionWidthV2(t *testing.T) {
-	assert.EqualValues(t, 8, new(V2).Width())
+	v := &V2{hash: sha1.New()}
+	assert.EqualValues(t, 8, v.Width())
 }
 
 func init() {

--- a/pack/packfile.go
+++ b/pack/packfile.go
@@ -3,6 +3,7 @@ package pack
 import (
 	"compress/zlib"
 	"fmt"
+	"hash"
 	"io"
 	"io/ioutil"
 )
@@ -17,6 +18,9 @@ type Packfile struct {
 	// idx is the corresponding "pack-*.idx" file giving the positions of
 	// objects in this packfile.
 	idx *Index
+
+	// hash is the hash algorithm used in this pack.
+	hash hash.Hash
 
 	// r is an io.ReaderAt that allows read access to the packfile itself.
 	r io.ReaderAt

--- a/pack/packfile.go
+++ b/pack/packfile.go
@@ -185,11 +185,13 @@ func (p *Packfile) find(offset int64) (Chain, error) {
 func (p *Packfile) findBase(typ PackedObjectType, offset, objOffset int64) (Chain, int64, error) {
 	var baseOffset int64
 
-	// We assume that we have to read at least 20 bytes (the SHA-1 length in
-	// the case of a OBJ_REF_DELTA, or greater than the length of the base
-	// offset encoded in an OBJ_OFS_DELTA).
-	var sha [20]byte
-	if _, err := p.r.ReadAt(sha[:], offset); err != nil {
+	hashlen := p.hash.Size()
+
+	// We assume that we have to read at least an object ID's worth (the
+	// hash length in the case of a OBJ_REF_DELTA, or greater than the
+	// length of the base offset encoded in an OBJ_OFS_DELTA).
+	var sha [32]byte
+	if _, err := p.r.ReadAt(sha[:hashlen], offset); err != nil {
 		return nil, baseOffset, err
 	}
 
@@ -217,13 +219,13 @@ func (p *Packfile) findBase(typ PackedObjectType, offset, objOffset int64) (Chai
 		// If the delta is an OBJ_REFS_DELTA, find the location of its
 		// base by reading the SHA-1 name and looking it up in the
 		// corresponding pack index file.
-		e, err := p.idx.Entry(sha[:])
+		e, err := p.idx.Entry(sha[:hashlen])
 		if err != nil {
 			return nil, baseOffset, err
 		}
 
 		baseOffset = int64(e.PackOffset)
-		offset += 20
+		offset += int64(hashlen)
 	default:
 		// If we did not receive an OBJ_OFS_DELTA, or OBJ_REF_DELTA, the
 		// type given is not a delta-fied type. Return an error.

--- a/pack/packfile_decode.go
+++ b/pack/packfile_decode.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"hash"
 	"io"
 )
 
@@ -22,7 +23,7 @@ var (
 //
 // If the header is malformed, or otherwise cannot be read, an error will be
 // returned without a corresponding packfile.
-func DecodePackfile(r io.ReaderAt) (*Packfile, error) {
+func DecodePackfile(r io.ReaderAt, hash hash.Hash) (*Packfile, error) {
 	header := make([]byte, 12)
 	if _, err := r.ReadAt(header[:], 0); err != nil {
 		return nil, err
@@ -40,5 +41,6 @@ func DecodePackfile(r io.ReaderAt) (*Packfile, error) {
 		Objects: objects,
 
 		r: r,
+		hash: hash,
 	}, nil
 }

--- a/pack/packfile_decode_test.go
+++ b/pack/packfile_decode_test.go
@@ -2,6 +2,8 @@ package pack
 
 import (
 	"bytes"
+	"crypto/sha1"
+	"crypto/sha256"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,7 +14,7 @@ func TestDecodePackfileDecodesIntegerVersion(t *testing.T) {
 		'P', 'A', 'C', 'K', // Pack header.
 		0x0, 0x0, 0x0, 0x2, // Pack version.
 		0x0, 0x0, 0x0, 0x0, // Number of packed objects.
-	}))
+	}), sha1.New())
 
 	assert.NoError(t, err)
 	assert.EqualValues(t, 2, p.Version)
@@ -23,7 +25,7 @@ func TestDecodePackfileDecodesIntegerCount(t *testing.T) {
 		'P', 'A', 'C', 'K', // Pack header.
 		0x0, 0x0, 0x0, 0x2, // Pack version.
 		0x0, 0x0, 0x1, 0x2, // Number of packed objects.
-	}))
+	}), sha256.New())
 
 	assert.NoError(t, err)
 	assert.EqualValues(t, 258, p.Objects)
@@ -34,7 +36,7 @@ func TestDecodePackfileReportsBadHeaders(t *testing.T) {
 		'W', 'R', 'O', 'N', 'G', // Malformed pack header.
 		0x0, 0x0, 0x0, 0x0, // Pack version.
 		0x0, 0x0, 0x0, 0x0, // Number of packed objects.
-	}))
+	}), sha1.New())
 
 	assert.Equal(t, errBadPackHeader, err)
 	assert.Nil(t, p)

--- a/pack/packfile_test.go
+++ b/pack/packfile_test.go
@@ -2,6 +2,7 @@ package pack
 
 import (
 	"bytes"
+	"crypto/sha1"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -30,6 +31,7 @@ func TestPackObjectReturnsObjectWithSingleBaseAtLowOffset(t *testing.T) {
 			// (0001 1000) (msb=0, type=commit, size=14)
 			0x1e}, compressed...),
 		),
+		hash: sha1.New(),
 	}
 
 	o, err := p.Object(DecodeHex(t, "cccccccccccccccccccccccccccccccccccccccc"))
@@ -63,6 +65,7 @@ func TestPackObjectReturnsObjectWithSingleBaseAtHighOffset(t *testing.T) {
 
 			compressed...,
 		)),
+		hash: sha1.New(),
 	}
 
 	o, err := p.Object(DecodeHex(t, "cccccccccccccccccccccccccccccccccccccccc"))
@@ -108,6 +111,7 @@ func TestPackObjectReturnsObjectWithDeltaBaseOffset(t *testing.T) {
 			0x6e, // (0110 1010) (msb=0, type=obj_ofs_delta, size=10)
 			0x12, // (0001 0001) (ofs_delta=-17, len(compressed))
 		}, delta...)...)),
+		hash: sha1.New(),
 	}
 
 	o, err := p.Object(DecodeHex(t, "cccccccccccccccccccccccccccccccccccccccc"))
@@ -160,6 +164,7 @@ func TestPackfileObjectReturnsObjectWithDeltaBaseReference(t *testing.T) {
 			0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc,
 			0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc,
 		}, delta...)...)),
+		hash: sha1.New(),
 	}
 
 	o, err := p.Object(DecodeHex(t, "dddddddddddddddddddddddddddddddddddddddd"))
@@ -261,7 +266,7 @@ func IndexWith(offsets map[string]uint32) *Index {
 		fanout: fanout,
 		r:      bytes.NewReader(buf),
 
-		version: new(V2),
+		version: &V2{hash: sha1.New()},
 	}
 }
 

--- a/pack/set.go
+++ b/pack/set.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/git-lfs/gitobj/errors"
+	"github.com/git-lfs/gitobj/v2/errors"
 )
 
 // Set allows access of objects stored across a set of packfiles.

--- a/pack/set.go
+++ b/pack/set.go
@@ -76,12 +76,12 @@ func NewSet(db string, algo hash.Hash) (*Set, error) {
 			return nil, err
 		}
 
-		pack, err := DecodePackfile(packf)
+		pack, err := DecodePackfile(packf, algo)
 		if err != nil {
 			return nil, err
 		}
 
-		idx, err := DecodeIndex(idxf)
+		idx, err := DecodeIndex(idxf, algo)
 		if err != nil {
 			return nil, err
 		}
@@ -139,7 +139,7 @@ func NewSetPacks(packs ...*Packfile) *Set {
 	}
 
 	return &Set{
-		m: m,
+		m:    m,
 		closeFn: func() error {
 			for _, pack := range packs {
 				if err := pack.Close(); err != nil {

--- a/pack/set.go
+++ b/pack/set.go
@@ -2,6 +2,7 @@ package pack
 
 import (
 	"fmt"
+	"hash"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -38,7 +39,7 @@ var (
 // containing them. If there was an error parsing the packfiles in that
 // directory, or the directory was otherwise unable to be observed, NewSet
 // returns that error.
-func NewSet(db string) (*Set, error) {
+func NewSet(db string, algo hash.Hash) (*Set, error) {
 	pd := filepath.Join(db, "pack")
 
 	paths, err := filepath.Glob(filepath.Join(escapeGlobPattern(pd), "*.pack"))

--- a/pack/storage.go
+++ b/pack/storage.go
@@ -1,6 +1,7 @@
 package pack
 
 import (
+	"hash"
 	"io"
 )
 
@@ -10,8 +11,8 @@ type Storage struct {
 }
 
 // NewStorage returns a new storage object based on a pack set.
-func NewStorage(root string) (*Storage, error) {
-	packs, err := NewSet(root)
+func NewStorage(root string, algo hash.Hash) (*Storage, error) {
+	packs, err := NewSet(root, algo)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/multi_storage.go
+++ b/storage/multi_storage.go
@@ -3,7 +3,7 @@ package storage
 import (
 	"io"
 
-	"github.com/git-lfs/gitobj/errors"
+	"github.com/git-lfs/gitobj/v2/errors"
 )
 
 // Storage implements an interface for reading, but not writing, objects in an

--- a/tag.go
+++ b/tag.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"hash"
 	"io"
 	"strings"
 )
@@ -24,7 +25,7 @@ type Tag struct {
 //
 // If any error was encountered along the way it will be returned, and the
 // receiving *Tag is considered invalid.
-func (t *Tag) Decode(r io.Reader, size int64) (int, error) {
+func (t *Tag) Decode(hash hash.Hash, r io.Reader, size int64) (int, error) {
 	scanner := bufio.NewScanner(io.LimitReader(r, size))
 
 	var (

--- a/tag_test.go
+++ b/tag_test.go
@@ -2,6 +2,7 @@ package gitobj
 
 import (
 	"bytes"
+	"crypto/sha1"
 	"fmt"
 	"testing"
 
@@ -52,7 +53,7 @@ func TestTagDecode(t *testing.T) {
 	flen := from.Len()
 
 	tag := new(Tag)
-	n, err := tag.Decode(from, int64(flen))
+	n, err := tag.Decode(sha1.New(), from, int64(flen))
 
 	assert.Nil(t, err)
 	assert.Equal(t, n, flen)

--- a/tree_test.go
+++ b/tree_test.go
@@ -3,6 +3,7 @@ package gitobj
 import (
 	"bufio"
 	"bytes"
+	"crypto/sha1"
 	"fmt"
 	"sort"
 	"strconv"
@@ -68,7 +69,7 @@ func TestTreeDecoding(t *testing.T) {
 	flen := from.Len()
 
 	tree := new(Tree)
-	n, err := tree.Decode(from, int64(flen))
+	n, err := tree.Decode(sha1.New(), from, int64(flen))
 
 	assert.Nil(t, err)
 	assert.Equal(t, flen, n)
@@ -106,7 +107,7 @@ func TestTreeDecodingShaBoundary(t *testing.T) {
 	flen := from.Len()
 
 	tree := new(Tree)
-	n, err := tree.Decode(bufio.NewReaderSize(&from, flen-2), int64(flen))
+	n, err := tree.Decode(sha1.New(), bufio.NewReaderSize(&from, flen-2), int64(flen))
 
 	assert.Nil(t, err)
 	assert.Equal(t, flen, n)


### PR DESCRIPTION
This series introduces support for SHA-256 into gitobj.  Git itself will likely learn support for SHA-256 in either 2.28 or 2.29, and we'll need to follow suit.

The series is split out into separate logical and independent patches.  It does introduce a breaking change to use a set of options for the object DB, so once it's merged we'll need to do a v2.0.0 release.  The `go.mod` and package paths are updated at the commit that introduces the breaking change.

Because many of the tests are very similar but just indented one more level, it may be helpful to review this series with whitespace ignored.  I've opted to use a set of integration tests to test the different algorithms because most of the tests for individual object types are not interested in the hash value, but rather various different parsing edge cases.