### PR TITLE
use max hash size constant for all SHA byte arrays

### DIFF
--- a/pack/index.go
+++ b/pack/index.go
@@ -7,7 +7,7 @@ import (
 	"io"
 )
 
-const maxHashSize = sha256.Size
+const MaxHashSize = sha256.Size
 
 // Index stores information about the location of objects in a corresponding
 // packfile.

--- a/pack/index_v1.go
+++ b/pack/index_v1.go
@@ -13,7 +13,7 @@ type V1 struct {
 // Name implements IndexVersion.Name by returning the 20 byte SHA-1 object name
 // for the given entry at offset "at" in the v1 index file "idx".
 func (v *V1) Name(idx *Index, at int64) ([]byte, error) {
-	var sha [maxHashSize]byte
+	var sha [MaxHashSize]byte
 
 	hashlen := v.hash.Size()
 

--- a/pack/index_v2.go
+++ b/pack/index_v2.go
@@ -13,7 +13,7 @@ type V2 struct {
 // Name implements IndexVersion.Name by returning the 20 byte SHA-1 object name
 // for the given entry at offset "at" in the v2 index file "idx".
 func (v *V2) Name(idx *Index, at int64) ([]byte, error) {
-	var sha [maxHashSize]byte
+	var sha [MaxHashSize]byte
 
 	hashlen := v.hash.Size()
 

--- a/pack/packfile.go
+++ b/pack/packfile.go
@@ -190,7 +190,7 @@ func (p *Packfile) findBase(typ PackedObjectType, offset, objOffset int64) (Chai
 	// We assume that we have to read at least an object ID's worth (the
 	// hash length in the case of a OBJ_REF_DELTA, or greater than the
 	// length of the base offset encoded in an OBJ_OFS_DELTA).
-	var sha [32]byte
+	var sha [MaxHashSize]byte
 	if _, err := p.r.ReadAt(sha[:hashlen], offset); err != nil {
 		return nil, baseOffset, err
 	}

--- a/tree.go
+++ b/tree.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+
+	"github.com/git-lfs/gitobj/v2/pack"
 )
 
 // Tree encapsulates a Git tree object.
@@ -53,7 +55,7 @@ func (t *Tree) Decode(hash hash.Hash, from io.Reader, size int64) (n int, err er
 		n += len(fname)
 		fname = strings.TrimSuffix(fname, "\x00")
 
-		var sha [32]byte
+		var sha [pack.MaxHashSize]byte
 		if _, err = io.ReadFull(buf, sha[:hashlen]); err != nil {
 			return n, err
 		}


### PR DESCRIPTION
Expanding on the introduction of the `maxHashSize` constant in 528473bb155f46fe058248cf7c25a672cbc07d29, we can use this in several other places as well for byte array initialization.