### PR TITLE
tree: don't use system stat constants

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -9,9 +9,19 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/git-lfs/gitobj/v2/pack"
+)
+
+// We define these here instead of using the system ones because not all
+// operating systems use the traditional values.  For example, zOS uses
+// different values.
+const (
+	sIFMT      = int32(0170000)
+	sIFREG     = int32(0100000)
+	sIFDIR     = int32(0040000)
+	sIFLNK     = int32(0120000)
+	sIFGITLINK = int32(0160000)
 )
 
 // Tree encapsulates a Git tree object.
@@ -209,24 +219,18 @@ func (e *TreeEntry) Equal(other *TreeEntry) bool {
 // Type is the type of entry (either blob: BlobObjectType, or a sub-tree:
 // TreeObjectType).
 func (e *TreeEntry) Type() ObjectType {
-	switch e.Filemode & syscall.S_IFMT {
-	case syscall.S_IFREG:
+	switch e.Filemode & sIFMT {
+	case sIFREG:
 		return BlobObjectType
-	case syscall.S_IFDIR:
+	case sIFDIR:
 		return TreeObjectType
-	case syscall.S_IFLNK:
+	case sIFLNK:
 		return BlobObjectType
+	case sIFGITLINK:
+		return CommitObjectType
 	default:
-		if e.Filemode == 0xe000 {
-			// Mode 0xe000, or a gitlink, has no formal filesystem
-			// (`syscall.S_IF<t>`) equivalent.
-			//
-			// Safeguard that catch here, or otherwise panic.
-			return CommitObjectType
-		} else {
-			panic(fmt.Sprintf("gitobj: unknown object type: %o",
-				e.Filemode))
-		}
+		panic(fmt.Sprintf("gitobj: unknown object type: %o",
+			e.Filemode))
 	}
 }
 


### PR DESCRIPTION
On most Unix systems, the stat constants (S_IFMT and friends) that Git uses are the same: that is, the system values are the same ones that Git uses.  However, on zOS, this isn't the case, and the system constants are different.

Let's add a set of our constants that are used by Git to determine the type of an object that will be right on all platforms instead of using the system constants.  Note that the tests already cover this case; they'll just now pass on additional systems.

Fixes #24