### PR TITLE
use filenames only as keys when merging tree entries

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -115,22 +115,18 @@ func (t *Tree) Encode(to io.Writer) (n int, err error) {
 func (t *Tree) Merge(others ...*TreeEntry) *Tree {
 	unseen := make(map[string]*TreeEntry)
 
-	// Build a cache of name+filemode to *TreeEntry.
+	// Build a cache of name to *TreeEntry.
 	for _, other := range others {
-		key := fmt.Sprintf("%s\x00%o", other.Name, other.Filemode)
-
-		unseen[key] = other
+		unseen[other.Name] = other
 	}
 
 	// Map the existing entries ("t.Entries") into a new set by either
 	// copying an existing entry, or replacing it with a new one.
 	entries := make([]*TreeEntry, 0, len(t.Entries))
 	for _, entry := range t.Entries {
-		key := fmt.Sprintf("%s\x00%o", entry.Name, entry.Filemode)
-
-		if other, ok := unseen[key]; ok {
+		if other, ok := unseen[entry.Name]; ok {
 			entries = append(entries, other)
-			delete(unseen, key)
+			delete(unseen, entry.Name)
 		} else {
 			oid := make([]byte, len(entry.Oid))
 			copy(oid, entry.Oid)

--- a/tree_test.go
+++ b/tree_test.go
@@ -123,7 +123,7 @@ func TestTreeDecodingShaBoundary(t *testing.T) {
 func TestTreeMergeReplaceElements(t *testing.T) {
 	e1 := &TreeEntry{Name: "a", Filemode: 0100644, Oid: []byte{0x1}}
 	e2 := &TreeEntry{Name: "b", Filemode: 0100644, Oid: []byte{0x2}}
-	e3 := &TreeEntry{Name: "c", Filemode: 0100644, Oid: []byte{0x3}}
+	e3 := &TreeEntry{Name: "c", Filemode: 0100755, Oid: []byte{0x3}}
 
 	e4 := &TreeEntry{Name: "b", Filemode: 0100644, Oid: []byte{0x4}}
 	e5 := &TreeEntry{Name: "c", Filemode: 0100644, Oid: []byte{0x5}}

--- a/tree_test.go
+++ b/tree_test.go
@@ -157,6 +157,7 @@ func TestMergeInsertElementsInSubtreeOrder(t *testing.T) {
 	assert.True(t, bytes.Equal(t1.Entries[1].Oid, []byte{0x2}))
 	assert.True(t, bytes.Equal(t1.Entries[2].Oid, []byte{0x3}))
 
+	require.Len(t, t2.Entries, 4)
 	assert.True(t, bytes.Equal(t2.Entries[0].Oid, []byte{0x4}))
 	assert.True(t, bytes.Equal(t2.Entries[1].Oid, []byte{0x1}))
 	assert.True(t, bytes.Equal(t2.Entries[2].Oid, []byte{0x2}))


### PR DESCRIPTION
The `Tree.Merge()` function should only use filenames as the keys of a tree object's entries, not filenames combined with file modes, which at present can result in duplicate file entries reported by `git fsck` as errors.

We therefore change to use only the entry's names as keys when merging new and existing tree entries together, and adjust the basic tree merge test such that it would fail without this change.

We also add an extra check to the subtree order merge test, just to bring the two merge tests into alignment.

/cc git-lfs/git-lfs#4796