### PR TITLE
add method to test if tree entries are symbolic links

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -234,6 +234,12 @@ func (e *TreeEntry) Type() ObjectType {
 	}
 }
 
+// IsLink returns true if the given TreeEntry is a blob which represents a
+// symbolic link (i.e., with a filemode of 0120000.
+func (e *TreeEntry) IsLink() bool {
+	return e.Filemode & sIFMT == sIFLNK
+}
+
 // SubtreeOrder is an implementation of sort.Interface that sorts a set of
 // `*TreeEntry`'s according to "subtree" order. This ordering is required to
 // write trees in a correct, readable format to the Git object database.

--- a/tree_test.go
+++ b/tree_test.go
@@ -166,9 +166,10 @@ func TestMergeInsertElementsInSubtreeOrder(t *testing.T) {
 type TreeEntryTypeTestCase struct {
 	Filemode int32
 	Expected ObjectType
+	IsLink bool
 }
 
-func (c *TreeEntryTypeTestCase) Assert(t *testing.T) {
+func (c *TreeEntryTypeTestCase) AssertType(t *testing.T) {
 	e := &TreeEntry{Filemode: c.Filemode}
 
 	got := e.Type()
@@ -177,14 +178,24 @@ func (c *TreeEntryTypeTestCase) Assert(t *testing.T) {
 		"gitobj: expected type: %s, got: %s", c.Expected, got)
 }
 
+func (c *TreeEntryTypeTestCase) AssertIsLink(t *testing.T) {
+	e := &TreeEntry{Filemode: c.Filemode}
+
+	isLink := e.IsLink()
+
+	assert.Equal(t, c.IsLink, isLink,
+		"gitobj: expected link: %v, got: %v, for type %s", c.IsLink, isLink, c.Expected)
+}
+
 func TestTreeEntryTypeResolution(t *testing.T) {
 	for desc, c := range map[string]*TreeEntryTypeTestCase{
-		"blob":    {0100644, BlobObjectType},
-		"subtree": {040000, TreeObjectType},
-		"symlink": {0120000, BlobObjectType},
-		"commit":  {0160000, CommitObjectType},
+		"blob":    {0100644, BlobObjectType, false},
+		"subtree": {040000, TreeObjectType, false},
+		"symlink": {0120000, BlobObjectType, true},
+		"commit":  {0160000, CommitObjectType, false},
 	} {
-		t.Run(desc, c.Assert)
+		t.Run(desc, c.AssertType)
+		t.Run(desc, c.AssertIsLink)
 	}
 }
 


### PR DESCRIPTION
Some callers may need to disambiguate between regular blob objects and those which represent symbolic links, so we add
an `IsLink()` method to the `TreeEntry` class that returns true when the object is a blob and a symlink, and false otherwise.

We also expand the test suite slightly to exercise this new method.