### PR TITLE
Mergetag parsing

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -123,13 +123,13 @@ func (c *Commit) Decode(hash hash.Hash, from io.Reader, size int64) (n int, err 
 			case "tree":
 				id, err := hex.DecodeString(fields[1])
 				if err != nil {
-					return n, err
+					return n, fmt.Errorf("error parsing tree: %s", err)
 				}
 				c.TreeID = id
 			case "parent":
 				id, err := hex.DecodeString(fields[1])
 				if err != nil {
-					return n, err
+					return n, fmt.Errorf("error parsing parent: %s", err)
 				}
 				c.ParentIDs = append(c.ParentIDs, id)
 			case "author":

--- a/commit.go
+++ b/commit.go
@@ -107,7 +107,7 @@ func (c *Commit) Decode(hash hash.Hash, from io.Reader, size int64) (n int, err 
 			continue
 		}
 
-		if fields := strings.Fields(text); !finishedHeaders {
+		if fields := strings.Split(text, " "); !finishedHeaders {
 			if len(fields) == 0 {
 				// Executing in this block means that we got a
 				// whitespace-only line, while parsing a header.


### PR DESCRIPTION
Git contains some multiline headers, including `gpgsig`, `gpgsig-sha256`, and `mergetag` headers.  These headers start with a normal line of data and then are continued after a newline by indentation with a single space, which is stripped when computing the body.

Our header parsing for commits could misparse these because we use `strings.Fields`, which strips leading space.  As a result, if the mergetag message contains a line starting with "tree " and then a non-hex character, we'd fail parsing since we'd attempt to parse it as a tree header.  Let's fix this by using `strings.Split` instead, which doesn't strip space and therefore won't try to misparse this.

The fake commit is synthesized from be122abe4bcd6d39b37892daae28c8bf5e4030fc in the Linux kernel repository. Identifying information and most of the text are removed for privacy and license reasons.