### PR TITLE
Update status badge and default branch name in security documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # gitobj
 
-[![](https://travis-ci.org/git-lfs/gitobj.svg?branch=master)](https://travis-ci.org/git-lfs/gitobj) [![](https://godoc.org/github.com/git-lfs/gitobj?status.svg)](https://godoc.org/github.com/git-lfs/gitobj)
+![CI status][1]
+
+[1]: https://github.com/git-lfs/gitobj/workflows/CI/badge.svg
 
 Package `gitobj` reads and writes loose and packed Git objects.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
 Please see
-[SECURITY.md](https://github.com/git-lfs/git-lfs/blob/master/SECURITY.md)
+[SECURITY.md](https://github.com/git-lfs/git-lfs/blob/main/SECURITY.md)
 in the main Git LFS repository for information on how to report security
 vulnerabilities in this package.


### PR DESCRIPTION
We're no longer using Travis CI, so we remove its status badge and add one for GitHub Actions.

We also update our link to the Git LFS project's main primary documentation in the `git-lfs/git-lfs` repository to use that repository's current default branch name of `main`.