### PR TITLE
Add link target to status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # gitobj
 
-![CI status][1]
+[![CI status][ci_badge]][ci_url]
 
-[1]: https://github.com/git-lfs/gitobj/workflows/CI/badge.svg
+[ci_badge]: https://github.com/git-lfs/gitobj/workflows/CI/badge.svg
+[ci_url]: https://github.com/git-lfs/gitobj/actions?query=workflow%3ACI
 
 Package `gitobj` reads and writes loose and packed Git objects.
 


### PR DESCRIPTION
In commit c735fc7bf09ba9c2944b9026d25baf7e75186ae8 of PR #31 we updated the CI status badge in our `README.md` file to reflect the fact that we are now using GitHub Actions rather than Travis CI.

However, we didn't include a link target for the new badge, so we do that now.