### PR TITLE
Update to Go 1.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     name: Default build
     strategy:
       matrix:
-        go: ['1.18.x', '1.19.x']
+        go: ['1.20.x', '1.21.x']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
 on: [push, pull_request]
+env:
+  GOTOOLCHAIN: local
 
 jobs:
   build-go:


### PR DESCRIPTION
As our official [policy](https://github.com/git-lfs/git-lfs/blob/a3829f486597702297737bb6677534cb5cd0bbc6/CONTRIBUTING.md#prerequisites) for the Git LFS project is to support the latest version of Go, we upgrade our CI workflow to version 1.21, which was recently released.

We also drop CI job runs (and therefore official support) for versions older than 1.20, as they are not supported by upstream Go.

Note that several older required CI jobs will not run for this PR, and the newer jobs should be marked as required after this PR is merged.