### PR TITLE
Fix decoding panic caused by wrong commit

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -145,7 +145,7 @@ func (c *Commit) Decode(hash hash.Hash, from io.Reader, size int64) (n int, err 
 					c.Committer = ""
 				}
 			default:
-				if strings.HasPrefix(s.Text(), " ") {
+				if strings.HasPrefix(text, " ") && len(c.ExtraHeaders) > 0 {
 					idx := len(c.ExtraHeaders) - 1
 					hdr := c.ExtraHeaders[idx]
 

--- a/commit_test.go
+++ b/commit_test.go
@@ -455,3 +455,20 @@ func TestCommitEqualReturnsTrueWhenBothCommitsAreNil(t *testing.T) {
 
 	assert.True(t, c1.Equal(c2))
 }
+
+func TestBadCommit(t *testing.T) {
+	cc := `tree 2aedfd35087c75d17bdbaf4dd56069d44fc75b71
+parent 75158117eb8efe60453f8c077527ac3530c81e38
+author Credit Card Account <Credit Card Account> 1722305889 +0800
+committer \346\244\260\346\235\215
+ <Credit Card Account> 1722305889 +0800
+
+Credit Card Account`
+	var c Commit
+	_, err := c.Decode(sha1.New(), strings.NewReader(cc), int64(len(cc)))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "decode error: '%v'\n", err)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "%v\n", c)
+}

--- a/commit_test.go
+++ b/commit_test.go
@@ -456,14 +456,15 @@ func TestCommitEqualReturnsTrueWhenBothCommitsAreNil(t *testing.T) {
 	assert.True(t, c1.Equal(c2))
 }
 
-func TestBadCommit(t *testing.T) {
+func TestCommitInvalidMultilineNonExtraHeader(t *testing.T) {
 	cc := `tree 2aedfd35087c75d17bdbaf4dd56069d44fc75b71
 parent 75158117eb8efe60453f8c077527ac3530c81e38
-author Credit Card Account <Credit Card Account> 1722305889 +0800
-committer \346\244\260\346\235\215
- <Credit Card Account> 1722305889 +0800
+author Jane Doe <jane@example.com> 1503956287 -0400
+committer Jane Doe <jane@example.com> 1503956287 -0400
+ foo bar
 
-Credit Card Account`
+initial commit`
+
 	var c Commit
 	_, err := c.Decode(sha1.New(), strings.NewReader(cc), int64(len(cc)))
 	assert.NoError(t, err)

--- a/commit_test.go
+++ b/commit_test.go
@@ -466,9 +466,5 @@ committer \346\244\260\346\235\215
 Credit Card Account`
 	var c Commit
 	_, err := c.Decode(sha1.New(), strings.NewReader(cc), int64(len(cc)))
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "decode error: '%v'\n", err)
-		return
-	}
-	fmt.Fprintf(os.Stderr, "%v\n", c)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
eg:

```
tree 2aedfd35087c75d17bdbaf4dd56069d44fc75b71
parent 75158117eb8efe60453f8c077527ac3530c81e38
author Credit Card Account <Credit Card Account> 1722305889 +0800
committer \346\244\260\346\235\215
 <Credit Card Account> 1722305889 +0800

Credit Card Account
```